### PR TITLE
fix; HeightmapExporter Sea Chart terrain on Wine/Proton

### DIFF
--- a/cpp-mods/HeightmapExporter/dllmain.cpp
+++ b/cpp-mods/HeightmapExporter/dllmain.cpp
@@ -21,7 +21,7 @@ using namespace RC;
 using namespace RC::Unreal;
 
 static bool isR(const void*a,size_t l){MEMORY_BASIC_INFORMATION m;if(!VirtualQuery(a,&m,sizeof(m)))return false;if(m.State!=MEM_COMMIT)return false;if(m.Protect&(PAGE_NOACCESS|PAGE_GUARD))return false;return(uintptr_t)a+l<=(uintptr_t)m.BaseAddress+m.RegionSize;}
-static bool vp(uint64_t v){return v>0x10000000000ULL&&v<0x7FFFFFFFFFFFULL;}
+static bool vp(uint64_t v){return v>0x10000ULL&&v<0x7FFFFFFFFFFFULL;}
 
 class HeightmapExporter : public CppUserModBase {
 public:


### PR DESCRIPTION
## Problem

When running the Windrose dedicated server under Wine (via the [Docker container](https://github.com/indifferentbroccoli/windrose-server-docker)), the Sea Chart terrain is completely blank — all 1,256 heightfield components silently fail to export any height data, resulting in a flat ocean map.

## Root Cause

The `vp()` pointer-validation function rejects any address below 1 TB (`0x10000000000`):

```cpp
static bool vp(uint64_t v){return v>0x10000000000ULL&&v<0x7FFFFFFFFFFFULL;}
```

On native Windows the game heap is allocated above this threshold, so the check passes. Under Wine the heap maps at ~4 GB (`0x100000000`) — well below the 1 TB floor — so every pointer in the heightfield dereference chain (`base+1448 → l1+48 → fhf+0x20 → hPtr`) is rejected before `isR()` is ever called.

### Wine vs native Windows memory layout

| Region | Native Windows | Wine 11 |
|---|---|---|
| Game heap | `0x10000000000`+ (above 1 TB) | `0x100000000`+ (~4 GB) |
| Game executable | `0x140000000` | `0x140000000` |
| UObject addresses | Above 1 TB | `0x3A000000`–`0x10AE10000` range |

## Fix

Lower the `vp()` threshold from 1 TB to 64 KB (`0x10000`):

```cpp
static bool vp(uint64_t v){return v>0x10000ULL&&v<0x7FFFFFFFFFFFULL;}
```

64 KB (`0x10000`) is the [Windows allocation granularity](https://learn.microsoft.com/en-us/windows/win32/api/sysinfoapi/ns-sysinfoapi-system_info) — no legitimate heap allocation will ever have an address below it on either native Windows or Wine. This preserves the original intent of filtering out NULL and garbage pointers while accepting Wine's lower heap range.

No change to `isR()` is needed — `VirtualQuery` works correctly under Wine 11 once the pointers actually reach it.

## Testing

Tested on an Ubuntu 22.04 Azure VM running `indifferentbroccoli/windrose-server-docker:v1.0.4` with Wine 11.0 and WindrosePlus v1.0.16.

### Before

- **0/1,256** components exported with height data
- Sea Chart displays flat ocean everywhere
- `terrain_v17.json` shows `"h":0` for all components

### After

- **1,252/1,256** components export valid height data
- 4 missing components are water-only tiles (no terrain geometry — expected)
- Full tile generation succeeds: 7 zoom levels, 5,461 tiles, ~28 MB
- Sea Chart renders correct terrain in the web dashboard

### Verification steps

1. Confirmed game UObject addresses fall in the `0x3A000000`–`0x10AE10000` range under Wine via `/proc/<pid>/maps` analysis and a diagnostic Lua mod
2. Binary-patched the compiled `main.dll` at the 6 offsets where MSVC inlined `vp()` constants (the compiler generated 3 separate inline copies with different optimization patterns — one using two raw `mov rax, imm64` comparisons and two using an optimised single-comparison `(v + addend) > range` pattern)
3. Triggered heightmap export, confirmed correct `terrain_v17.json` output and valid `.bin` heightmap files
4. Verified the Sea Chart rendered correctly in the WindrosePlus web dashboard
5. Confirmed the binary patch is logically equivalent to this source-level change

## Impact

- **Wine/Proton:** Fixes Sea Chart terrain completely
- **Native Windows:** No functional change — all game heap addresses on native Windows are well above 64 KB
