### PR TITLE
Add SEA CHART click-to-teleport with on-ship position fix and real-time entity tracking

### DIFF
--- a/WindrosePlus/Scripts/modules/admin.lua
+++ b/WindrosePlus/Scripts/modules/admin.lua
@@ -596,13 +596,16 @@ function Admin._registerCommands()
                 end
             end
 
-            -- Push the new position to the dashboard immediately rather than waiting
-            -- for the next LiveMap interval. Keeps the click-to-teleport UI snappy
-            -- without forcing a faster default interval on every server.
+            -- Request the next LiveMap tick force a write so the new player position
+            -- reaches the dashboard immediately rather than waiting up to one
+            -- _playerInterval. We only set a flag here — the actual UObject collection
+            -- runs in writeIfDue on the game-thread-dispatched path, never from this
+            -- RCON command-processing thread (preserves the dispatchTick / degraded-mode
+            -- protection introduced for #33/#46).
             if anyTeleported then
                 local LiveMap = WindrosePlus._modules and WindrosePlus._modules.LiveMap
-                if LiveMap and LiveMap.forceWrite then
-                    pcall(LiveMap.forceWrite)
+                if LiveMap and LiveMap.requestForceWrite then
+                    pcall(LiveMap.requestForceWrite)
                 end
             end
 

--- a/WindrosePlus/Scripts/modules/admin.lua
+++ b/WindrosePlus/Scripts/modules/admin.lua
@@ -519,6 +519,98 @@ function Admin._registerCommands()
         end
     }
 
+    -- Teleport an online player to absolute world coordinates (UU/cm).
+    -- Z is optional — if omitted, player's current Z is preserved (works well for
+    -- short hops; for cross-map jumps the SEA CHART click-to-teleport in the
+    -- dashboard supplies a heightmap-derived Z so the player lands above terrain).
+    Admin._commands["wp.tp"] = {
+        description = "Teleport player to absolute world coordinates (X, Y, optional Z)",
+        usage = "wp.tp [player] <x> <y> [z]",
+        category = "admin",
+        examples = {"wp.tp 100000 200000", "wp.tp HumanGenome 100000 200000 5000"},
+        playerArg = true,
+        handler = function(args)
+            local n = #args
+            if n < 2 then return "Usage: wp.tp [player] <x> <y> [z]" end
+
+            -- Trailing 2 or 3 args are numeric coords; everything before is the (possibly
+            -- multi-word) player name. Same disambiguation pattern as wp.speed.
+            local last1 = tonumber(args[n])
+            local last2 = n >= 2 and tonumber(args[n-1]) or nil
+            local last3 = n >= 3 and tonumber(args[n-2]) or nil
+            local x, y, z, nameEnd
+            if last3 and last2 and last1 then
+                x, y, z = last3, last2, last1
+                nameEnd = n - 3
+            elseif last2 and last1 then
+                x, y = last2, last1
+                nameEnd = n - 2
+            else
+                return "Need 2 or 3 trailing numeric coords (x y [z])"
+            end
+            local targetName = nameEnd > 0 and table.concat(args, " ", 1, nameEnd):lower() or nil
+
+            local pcs = FindAllOf("PlayerController")
+            if not pcs then return "No players found" end
+
+            local results = {}
+            local matched = 0
+            local anyTeleported = false
+            for _, pc in ipairs(pcs) do
+                if pc:IsValid() then
+                    local pName = getPlayerName(pc)
+                    local nameMatch = not targetName or (pName and pName:lower() == targetName)
+                    if nameMatch then
+                        matched = matched + 1
+                        pcall(function()
+                            local pawn = pc.Pawn
+                            if not (pawn and pawn:IsValid()) then
+                                table.insert(results, (pName or "?") .. ": no pawn")
+                                return
+                            end
+
+                            -- Use current Z if not given
+                            local targetZ = z
+                            if not targetZ then
+                                local locOk, loc = pcall(function() return pawn:K2_GetActorLocation() end)
+                                if locOk and loc and loc.Z then targetZ = loc.Z else targetZ = 0 end
+                            end
+
+                            local newLoc = { X = x, Y = y, Z = targetZ }
+                            -- K2_SetActorLocation(NewLocation, bSweep, OutSweepHitResult, bTeleport)
+                            -- bSweep=false: don't collide-test against world while moving
+                            -- bTeleport=true: discontinuous move, signals to physics/replication
+                            --   that this is intentional (vs. a desync, which would rubber-band)
+                            local callOk, ret = pcall(function()
+                                return pawn:K2_SetActorLocation(newLoc, false, {}, true)
+                            end)
+                            if not callOk then
+                                table.insert(results, string.format("%s: ERR %s", pName or "?", tostring(ret)))
+                                return
+                            end
+                            anyTeleported = true
+                            table.insert(results, string.format("%s: tp -> (%.0f, %.0f, %.0f) ret=%s",
+                                pName or "?", x, y, targetZ, tostring(ret)))
+                        end)
+                    end
+                end
+            end
+
+            -- Push the new position to the dashboard immediately rather than waiting
+            -- for the next LiveMap interval. Keeps the click-to-teleport UI snappy
+            -- without forcing a faster default interval on every server.
+            if anyTeleported then
+                local LiveMap = WindrosePlus._modules and WindrosePlus._modules.LiveMap
+                if LiveMap and LiveMap.forceWrite then
+                    pcall(LiveMap.forceWrite)
+                end
+            end
+
+            if matched == 0 then return "No matching player" end
+            return table.concat(results, "\n")
+        end,
+    }
+
     -- =========================================
     -- Real-time Game Settings (modify UE4 objects live)
     -- =========================================

--- a/WindrosePlus/Scripts/modules/livemap.lua
+++ b/WindrosePlus/Scripts/modules/livemap.lua
@@ -20,6 +20,7 @@ LiveMap._wroteEmpty = false
 LiveMap._lastSnapshot = nil
 LiveMap._lastSnapshotTs = 0
 LiveMap._pendingContent = nil
+LiveMap._forceRequested = false  -- consumed by writeIfDue on the game-thread dispatch path
 
 local function cloneTable(t)
     if type(t) ~= "table" then return t end
@@ -72,8 +73,13 @@ function LiveMap.writeIfDue()
     LiveMap._wroteEmpty = false
 
     local now = os.time()
-    local playersDue = (now - LiveMap._lastPlayerWrite >= LiveMap._playerInterval)
-    local entitiesDue = (now - LiveMap._lastEntityWrite >= LiveMap._entityInterval)
+    -- Honor a pending force-write request (e.g. set from wp.tp). Consume the flag
+    -- here on the game-thread-dispatched path so UObject collection never runs
+    -- from the RCON command-processing thread.
+    local forced = LiveMap._forceRequested
+    if forced then LiveMap._forceRequested = false end
+    local playersDue = forced or (now - LiveMap._lastPlayerWrite >= LiveMap._playerInterval)
+    local entitiesDue = forced or (now - LiveMap._lastEntityWrite >= LiveMap._entityInterval)
 
     if not playersDue then return end
     LiveMap._lastPlayerWrite = now
@@ -90,6 +96,13 @@ function LiveMap.writeIfDue()
     end
 
     LiveMap._collectAndWrite(collectEntities, allPlayers)
+end
+
+-- Request that the next writeIfDue tick force a write regardless of interval timing.
+-- Safe to call from any thread (RCON command handlers, async tasks) — only sets a flag.
+-- The actual UObject collection happens in writeIfDue on the game-thread-dispatched path.
+function LiveMap.requestForceWrite()
+    LiveMap._forceRequested = true
 end
 
 function LiveMap._collectAndWrite(collectEntities, prefetchedPlayers)

--- a/WindrosePlus/Scripts/modules/livemap.lua
+++ b/WindrosePlus/Scripts/modules/livemap.lua
@@ -128,10 +128,19 @@ function LiveMap._collectAndWrite(collectEntities, prefetchedPlayers)
                                 m.name = fn:match("BP_([^_]+)") or "Mob"
                             end
                         end)
+                        -- K2_GetActorLocation() walks attachment hierarchy and returns
+                        -- true world coords; ReplicatedMovement.Location reads (0,0,0)
+                        -- for actors attached to moving parents (ships, etc.).
                         pcall(function()
-                            local loc = pawn.ReplicatedMovement.Location
+                            local loc = pawn:K2_GetActorLocation()
                             if loc then m.x = loc.X; m.y = loc.Y; m.z = loc.Z end
                         end)
+                        if not m.x then
+                            pcall(function()
+                                local loc = pawn.ReplicatedMovement.Location
+                                if loc then m.x = loc.X; m.y = loc.Y; m.z = loc.Z end
+                            end)
+                        end
                         if m.x then table.insert(mobs, m) end
                     end
                 end
@@ -148,9 +157,15 @@ function LiveMap._collectAndWrite(collectEntities, prefetchedPlayers)
                         n.name = fn:match("BP_([^_]+)") or "Mineral"
                     end)
                     pcall(function()
-                        local loc = node.ReplicatedMovement.Location
+                        local loc = node:K2_GetActorLocation()
                         if loc then n.x = loc.X; n.y = loc.Y; n.z = loc.Z end
                     end)
+                    if not n.x then
+                        pcall(function()
+                            local loc = node.ReplicatedMovement.Location
+                            if loc then n.x = loc.X; n.y = loc.Y; n.z = loc.Z end
+                        end)
+                    end
                     if not n.x then
                         pcall(function()
                             local root = node.RootComponent

--- a/WindrosePlus/Scripts/modules/query.lua
+++ b/WindrosePlus/Scripts/modules/query.lua
@@ -207,10 +207,20 @@ function Query.getPlayers()
             pcall(function()
                 local pawn = pc.Pawn
                 if pawn and pawn:IsValid() then
+                    -- K2_GetActorLocation() traverses the attachment hierarchy and returns
+                    -- true world coords. ReplicatedMovement.Location stops giving world
+                    -- coords when the pawn is attached to a moving parent (e.g. on a ship),
+                    -- producing (0,0,0) for boarded players.
                     pcall(function()
-                        local loc = pawn.ReplicatedMovement.Location
+                        local loc = pawn:K2_GetActorLocation()
                         if loc then p.x = loc.X; p.y = loc.Y; p.z = loc.Z end
                     end)
+                    if not p.x then
+                        pcall(function()
+                            local loc = pawn.ReplicatedMovement.Location
+                            if loc then p.x = loc.X; p.y = loc.Y; p.z = loc.Z end
+                        end)
+                    end
                     pcall(function()
                         local hc = pawn.HealthComponent
                         if hc and hc:IsValid() then

--- a/server/web/index.html
+++ b/server/web/index.html
@@ -1324,6 +1324,11 @@
                         const row = document.createElement('div');
                         row.className = 'player-row';
                         row.dataset.player = p.name || '';
+                        // Stash current Z on the row so the click handler has a fallback
+                        // if /api/terrain_height returns null (ocean / out-of-bounds /
+                        // pre-export). Always sending a Z avoids an arg-parser ambiguity
+                        // in wp.tp when player names are numeric or end in a numeric token.
+                        row.dataset.playerZ = p.z != null ? Math.round(p.z) : '';
                         if (tpArmedPlayer && tpArmedPlayer === p.name) {
                             row.classList.add('tp-armed');
                         }
@@ -1810,6 +1815,7 @@
         // `wp.tp <player> <x> <y> [z]` and disarms. ESC or re-clicking the same TELEPORT
         // button cancels and reverts the row coords to the player's actual position.
         var tpArmedPlayer = null;
+        var tpArmedPlayerZ = null;  // captured at arm time as a fallback Z for click commits
         var tpPreviewCoords = null;
 
         function armTeleport(playerName) {
@@ -1824,7 +1830,15 @@
             // Reflect in the row UI immediately (the next /api/status refresh will also keep it).
             document.querySelectorAll('.player-row').forEach(function(r) { r.classList.remove('tp-armed'); });
             var row = document.querySelector('.player-row[data-player="' + (window.CSS && CSS.escape ? CSS.escape(playerName) : playerName) + '"]');
-            if (row) row.classList.add('tp-armed');
+            if (row) {
+                row.classList.add('tp-armed');
+                // Capture the player's current Z so we can fall back to it at click time
+                // if /api/terrain_height has no land data for the click point.
+                var pz = row.dataset.playerZ;
+                tpArmedPlayerZ = (pz !== '' && pz != null) ? parseInt(pz, 10) : null;
+            } else {
+                tpArmedPlayerZ = null;
+            }
 
             // Auto-switch to SEA CHART tab and prep the map.
             var seachartTab = document.querySelector('.dashboard-tab[data-tab="seachart"]');
@@ -1845,6 +1859,7 @@
 
         function disarmTeleport() {
             tpArmedPlayer = null;
+            tpArmedPlayerZ = null;
             tpPreviewCoords = null;
             document.querySelectorAll('.player-row.tp-armed').forEach(function(r) { r.classList.remove('tp-armed'); });
             // Restore any preview-styled position fields to the actual coords.
@@ -2015,30 +2030,46 @@
                 //   - terrain Z < 0 (shoreline / underwater): float 3m above sea level —
                 //     the pawn capsule extends below the feet pivot and water shaders
                 //     make even +1m look "in water", so we need more clearance
-                // If the endpoint returns z:null (ocean / out-of-bounds) or the request
-                // fails, we omit Z and `wp.tp` preserves the player's current Z.
+                //
+                // We ALWAYS send a Z (never the 3-arg `wp.tp <name> <x> <y>` form). When
+                // terrain data is unavailable (ocean / out-of-bounds / pre-heightmap-export
+                // / endpoint unreachable) we fall back to the armed player's current Z
+                // captured at arm time. This avoids an arg-parser ambiguity in wp.tp where
+                // a numeric or numeric-suffix player name could be misread as a coord.
+                function commitTeleport(player, x, y, z) {
+                    sendRconCommand('wp.tp ' + player + ' ' + x + ' ' + y + ' ' + z);
+                }
+
                 seachartMap.on('click', function(e) {
                     if (!tpArmedPlayer) return;
                     var x = Math.round(e.latlng.lng);
                     var y = Math.round(e.latlng.lat);
                     var player = tpArmedPlayer;
+                    var fallbackZ = tpArmedPlayerZ;  // captured at arm time
                     disarmTeleport();
 
                     fetch('/api/terrain_height?x=' + x + '&y=' + y)
                         .then(function(r) { return r.json(); })
                         .then(function(data) {
-                            var cmd = 'wp.tp ' + player + ' ' + x + ' ' + y;
+                            var z;
                             if (data && typeof data.z === 'number') {
-                                var z = data.z >= 0
+                                z = data.z >= 0
                                     ? Math.round(data.z + 100)
                                     : 300;
-                                cmd += ' ' + z;
+                            } else if (fallbackZ != null) {
+                                // Terrain data unavailable — keep player at their current Z.
+                                z = fallbackZ;
+                            } else {
+                                // Last resort: float just above sea level.
+                                z = 300;
                             }
-                            sendRconCommand(cmd);
+                            commitTeleport(player, x, y, z);
                         })
                         .catch(function() {
-                            // Endpoint unreachable — fall back to no-Z behavior.
-                            sendRconCommand('wp.tp ' + player + ' ' + x + ' ' + y);
+                            // Endpoint unreachable — fall back to player's current Z, or
+                            // a sea-level float if that's somehow missing too.
+                            var z = fallbackZ != null ? fallbackZ : 300;
+                            commitTeleport(player, x, y, z);
                         });
                 });
 

--- a/server/web/index.html
+++ b/server/web/index.html
@@ -350,13 +350,78 @@
 
         .player-row {
             display: grid;
-            grid-template-columns: auto minmax(0, 1fr) auto;
+            grid-template-columns: auto minmax(0, 1fr) auto auto;
             align-items: center;
             gap: 10px;
             padding: 6px 8px;
             border-radius: 8px;
             border: 1px solid rgba(212, 160, 74, 0.08);
             background: rgba(255, 248, 230, 0.02);
+            transition: border-color 0.15s ease, background 0.15s ease;
+        }
+
+        .player-row.tp-armed {
+            border-color: rgba(212, 160, 74, 0.5);
+            background: rgba(212, 160, 74, 0.07);
+        }
+
+        .player-tp-btn {
+            background: transparent;
+            border: 1px solid rgba(212, 160, 74, 0.25);
+            color: var(--text-muted);
+            font-family: 'Cinzel', serif;
+            font-size: 0.66rem;
+            font-weight: 700;
+            letter-spacing: 0.12em;
+            text-transform: uppercase;
+            padding: 3px 10px;
+            border-radius: 4px;
+            cursor: pointer;
+            transition: all 0.15s ease;
+        }
+
+        .player-tp-btn:hover {
+            border-color: var(--accent);
+            color: var(--accent);
+            background: rgba(212, 160, 74, 0.05);
+        }
+
+        .player-row.tp-armed .player-tp-btn {
+            border-color: var(--accent);
+            color: var(--accent);
+            background: rgba(212, 160, 74, 0.12);
+        }
+
+        #seachart-map.tp-armed,
+        #seachart-map.tp-armed .leaflet-container,
+        #seachart-map.tp-armed .leaflet-grab,
+        #seachart-map.tp-armed .leaflet-interactive {
+            cursor: crosshair !important;
+        }
+
+        .tp-hint-banner {
+            position: absolute;
+            top: 14px;
+            left: 50%;
+            transform: translateX(-50%);
+            background: rgba(20, 16, 10, 0.92);
+            border: 1px solid var(--accent);
+            color: var(--accent);
+            padding: 7px 16px;
+            border-radius: 6px;
+            font-size: 0.9rem;
+            font-family: 'Cormorant Garamond', serif;
+            letter-spacing: 0.03em;
+            z-index: 1000;
+            pointer-events: none;
+            box-shadow: 0 4px 16px rgba(0, 0, 0, 0.6);
+        }
+
+        .tp-hint-banner .hint-key {
+            font-family: 'IBM Plex Mono', monospace;
+            font-size: 0.72rem;
+            color: var(--text-muted);
+            margin-left: 8px;
         }
 
         .player-dot {
@@ -386,6 +451,19 @@
             font-size: 0.78rem;
             color: var(--text-muted);
             white-space: nowrap;
+            transition: color 0.15s ease;
+        }
+
+        .player-pos.tp-preview {
+            color: var(--accent);
+            font-style: italic;
+        }
+
+        .tp-hint-coords {
+            font-family: 'IBM Plex Mono', monospace;
+            font-size: 0.78rem;
+            margin: 0 8px;
+            color: var(--text);
         }
 
         .empty-state {
@@ -1159,6 +1237,7 @@
             </div>
             <div class="tab-content" id="seachart-pane">
                 <div id="seachart-map"></div>
+                <div class="tp-hint-banner" id="tp-hint-banner" style="display:none;"></div>
             </div>
 
             <!-- Hidden elements preserved for test compatibility -->
@@ -1244,6 +1323,10 @@
                     for (const p of players) {
                         const row = document.createElement('div');
                         row.className = 'player-row';
+                        row.dataset.player = p.name || '';
+                        if (tpArmedPlayer && tpArmedPlayer === p.name) {
+                            row.classList.add('tp-armed');
+                        }
 
                         const dot = document.createElement('div');
                         dot.className = 'player-dot' + (p.alive === false ? ' dead' : '');
@@ -1252,13 +1335,31 @@
                         name.className = 'player-name';
                         name.textContent = p.name || 'Unknown';
 
+                        const tpBtn = document.createElement('button');
+                        tpBtn.className = 'player-tp-btn';
+                        tpBtn.type = 'button';
+                        tpBtn.textContent = 'TELEPORT';
+                        tpBtn.title = 'Teleport ' + (p.name || 'this player') + ' — then click anywhere on the SEA CHART';
+                        tpBtn.addEventListener('click', (ev) => {
+                            ev.stopPropagation();
+                            armTeleport(p.name);
+                        });
+
                         const pos = document.createElement('span');
                         pos.className = 'player-pos';
-                        if (p.x != null) {
-                            pos.textContent = `${Math.round(p.x)}, ${Math.round(p.y)}`;
+                        const actualPosText = p.x != null ? `${Math.round(p.x)}, ${Math.round(p.y)}` : '';
+                        // If this is the armed player and a preview is active, keep showing
+                        // the cursor coords; stash the actual position so disarm/mouseout
+                        // can revert without waiting for the next status refresh.
+                        if (tpArmedPlayer === p.name && tpPreviewCoords) {
+                            pos.textContent = `${tpPreviewCoords.x}, ${tpPreviewCoords.y}`;
+                            pos.classList.add('tp-preview');
+                            pos.dataset.origText = actualPosText;
+                        } else {
+                            pos.textContent = actualPosText;
                         }
 
-                        row.append(dot, name, pos);
+                        row.append(dot, name, tpBtn, pos);
                         list.appendChild(row);
                     }
                 }
@@ -1699,6 +1800,115 @@
         // Tab switching
         var seachartInitialized = false;
         var seachartMap = null;
+
+        // -------- Click-to-teleport state --------
+        // The TELEPORT button on each player row "arms" a teleport for that player. While
+        // armed, the SEA CHART map shows a crosshair cursor and a hint banner. As the
+        // cursor moves over the map, tpPreviewCoords tracks the hover point and we mirror
+        // it into the player row's coords field (in italic accent) and the banner — so
+        // the admin sees exactly where the click would land. The next map click sends
+        // `wp.tp <player> <x> <y> [z]` and disarms. ESC or re-clicking the same TELEPORT
+        // button cancels and reverts the row coords to the player's actual position.
+        var tpArmedPlayer = null;
+        var tpPreviewCoords = null;
+
+        function armTeleport(playerName) {
+            if (!playerName) return;
+            // Toggle off if same player already armed
+            if (tpArmedPlayer === playerName) {
+                disarmTeleport();
+                return;
+            }
+            tpArmedPlayer = playerName;
+
+            // Reflect in the row UI immediately (the next /api/status refresh will also keep it).
+            document.querySelectorAll('.player-row').forEach(function(r) { r.classList.remove('tp-armed'); });
+            var row = document.querySelector('.player-row[data-player="' + (window.CSS && CSS.escape ? CSS.escape(playerName) : playerName) + '"]');
+            if (row) row.classList.add('tp-armed');
+
+            // Auto-switch to SEA CHART tab and prep the map.
+            var seachartTab = document.querySelector('.dashboard-tab[data-tab="seachart"]');
+            if (seachartTab && !seachartTab.classList.contains('active')) {
+                seachartTab.click();
+            }
+            var mapEl = document.getElementById('seachart-map');
+            if (mapEl) mapEl.classList.add('tp-armed');
+
+            var banner = document.getElementById('tp-hint-banner');
+            if (banner) {
+                banner.innerHTML = 'Click the map to teleport <strong>' + escHtmlGlobal(playerName) + '</strong>'
+                    + '<span class="tp-hint-coords" id="tp-hint-coords"></span>'
+                    + '<span class="hint-key">ESC to cancel</span>';
+                banner.style.display = 'block';
+            }
+        }
+
+        function disarmTeleport() {
+            tpArmedPlayer = null;
+            tpPreviewCoords = null;
+            document.querySelectorAll('.player-row.tp-armed').forEach(function(r) { r.classList.remove('tp-armed'); });
+            // Restore any preview-styled position fields to the actual coords.
+            document.querySelectorAll('.player-pos.tp-preview').forEach(function(el) {
+                el.classList.remove('tp-preview');
+                if (el.dataset.origText != null) {
+                    el.textContent = el.dataset.origText;
+                    delete el.dataset.origText;
+                }
+            });
+            var mapEl = document.getElementById('seachart-map');
+            if (mapEl) mapEl.classList.remove('tp-armed');
+            var banner = document.getElementById('tp-hint-banner');
+            if (banner) banner.style.display = 'none';
+        }
+
+        // Update the armed player's row coords + banner to reflect the cursor position.
+        // Called on map mousemove while armed. Stashes the original text on first call so
+        // we can restore it on mouseout / disarm.
+        function updateTeleportPreview(x, y) {
+            tpPreviewCoords = { x: x, y: y };
+            if (!tpArmedPlayer) return;
+            var sel = '.player-row[data-player="' + (window.CSS && CSS.escape ? CSS.escape(tpArmedPlayer) : tpArmedPlayer) + '"]';
+            var row = document.querySelector(sel);
+            if (row) {
+                var pos = row.querySelector('.player-pos');
+                if (pos) {
+                    if (pos.dataset.origText == null) pos.dataset.origText = pos.textContent;
+                    pos.textContent = x + ', ' + y;
+                    pos.classList.add('tp-preview');
+                }
+            }
+            var coordsEl = document.getElementById('tp-hint-coords');
+            if (coordsEl) coordsEl.textContent = '(' + x + ', ' + y + ')';
+        }
+
+        // Called when cursor leaves the map (or on disarm) — revert preview without
+        // clearing tpArmedPlayer (so a re-enter resumes the preview).
+        function clearTeleportPreview() {
+            tpPreviewCoords = null;
+            document.querySelectorAll('.player-pos.tp-preview').forEach(function(el) {
+                el.classList.remove('tp-preview');
+                if (el.dataset.origText != null) {
+                    el.textContent = el.dataset.origText;
+                    delete el.dataset.origText;
+                }
+            });
+            var coordsEl = document.getElementById('tp-hint-coords');
+            if (coordsEl) coordsEl.textContent = '';
+        }
+
+        function escHtmlGlobal(s) {
+            var d = document.createElement('div');
+            d.appendChild(document.createTextNode(String(s)));
+            return d.innerHTML;
+        }
+
+        // ESC anywhere disarms.
+        document.addEventListener('keydown', function(e) {
+            if (e.key === 'Escape' && tpArmedPlayer) {
+                disarmTeleport();
+            }
+        });
+
         document.querySelectorAll('.dashboard-tab').forEach(function(btn) {
             btn.addEventListener('click', function() {
                 var tab = this.getAttribute('data-tab');
@@ -1780,6 +1990,57 @@
 
                 var playerLayer = L.layerGroup().addTo(seachartMap);
                 var mobLayer = L.layerGroup().addTo(seachartMap);
+
+                // Live preview: as the cursor moves while armed, mirror the hover point
+                // into the player row's coords field and the hint banner.
+                seachartMap.on('mousemove', function(e) {
+                    if (!tpArmedPlayer) return;
+                    updateTeleportPreview(Math.round(e.latlng.lng), Math.round(e.latlng.lat));
+                });
+                seachartMap.on('mouseout', function() {
+                    if (!tpArmedPlayer) return;
+                    clearTeleportPreview();
+                });
+
+                // Click-to-teleport. Active only when a player is armed via the TELEPORT
+                // button in the player list. Leaflet's CRS already maps lat/lng to world
+                // Y/X 1:1 (see L.marker(L.latLng(p.y, p.x)) below), so click coords are
+                // world coords directly — no projection math.
+                //
+                // For Z: we ask /api/terrain_height to sample the exported heightmap at
+                // (X, Y). Sea level is Z=0 in Windrose's heightfield. Different clearances
+                // for land vs water:
+                //   - terrain Z >= 0 (dry land): land 1m above terrain — small offset so
+                //     mountain/grass clicks don't make the player visibly drop
+                //   - terrain Z < 0 (shoreline / underwater): float 3m above sea level —
+                //     the pawn capsule extends below the feet pivot and water shaders
+                //     make even +1m look "in water", so we need more clearance
+                // If the endpoint returns z:null (ocean / out-of-bounds) or the request
+                // fails, we omit Z and `wp.tp` preserves the player's current Z.
+                seachartMap.on('click', function(e) {
+                    if (!tpArmedPlayer) return;
+                    var x = Math.round(e.latlng.lng);
+                    var y = Math.round(e.latlng.lat);
+                    var player = tpArmedPlayer;
+                    disarmTeleport();
+
+                    fetch('/api/terrain_height?x=' + x + '&y=' + y)
+                        .then(function(r) { return r.json(); })
+                        .then(function(data) {
+                            var cmd = 'wp.tp ' + player + ' ' + x + ' ' + y;
+                            if (data && typeof data.z === 'number') {
+                                var z = data.z >= 0
+                                    ? Math.round(data.z + 100)
+                                    : 300;
+                                cmd += ' ' + z;
+                            }
+                            sendRconCommand(cmd);
+                        })
+                        .catch(function() {
+                            // Endpoint unreachable — fall back to no-Z behavior.
+                            sendRconCommand('wp.tp ' + player + ' ' + x + ' ' + y);
+                        });
+                });
 
                 function escHtml(s) { var d = document.createElement('div'); d.appendChild(document.createTextNode(s)); return d.innerHTML; }
 

--- a/server/windrose_plus_server.ps1
+++ b/server/windrose_plus_server.ps1
@@ -289,6 +289,96 @@ function Write-AtomicUtf8Json($path, $data) {
     Move-Item -LiteralPath $tmpPath -Destination $path -Force
 }
 
+# --- Terrain heightmap sampling (for click-to-teleport on the SEA CHART) ---
+# The dashboard already has full elevation data exported by HeightmapExporter:
+#   windrose_plus_data/terrain_v17.json   — manifest of components (wx, wy, minZ, maxZ, res, file)
+#   windrose_plus_data/heightmaps/*.bin   — uint16 heightfield grids per component
+# Component binary format: int32 res, then res*res uint16 samples.
+# Sample formula: worldZ = minZ + (raw / 65535) * (maxZ - minZ).
+# Components with maxZ < 100 are ocean floor (per generateTiles.ps1's seaLevelThreshold);
+# we skip those so a click over ocean falls back to "preserve current Z" rather than
+# teleporting the player to the sea floor.
+$script:TerrainCacheReady = $false
+$script:TerrainLandComps = $null
+
+function Initialize-TerrainCache($DataDir) {
+    if ($script:TerrainCacheReady) { return $true }
+    $jsonPath = Join-Path $DataDir "terrain_v17.json"
+    if (-not (Test-Path -LiteralPath $jsonPath)) { return $false }
+    try {
+        $meta = Get-Content $jsonPath -Raw | ConvertFrom-Json
+    } catch { return $false }
+
+    # Per-landscape step (delta between consecutive sx values; defines compW = step * scale)
+    $byLand = @{}
+    foreach ($c in $meta.components) {
+        $li = [string]$c.l
+        if (-not $byLand.ContainsKey($li)) { $byLand[$li] = @() }
+        $byLand[$li] += $c
+    }
+    $landSteps = @{}
+    foreach ($li in $byLand.Keys) {
+        $sxs = @($byLand[$li] | ForEach-Object { $_.sx } | Sort-Object -Unique)
+        if ($sxs.Count -gt 1) { $landSteps[$li] = $sxs[1] - $sxs[0] }
+        else { $landSteps[$li] = 255 }
+    }
+
+    $comps = New-Object System.Collections.Generic.List[object]
+    foreach ($c in $meta.components) {
+        if ($c.h -ne 1) { continue }
+        $maxZ = if ($null -ne $c.maxZ) { [double]$c.maxZ } else { 1.0 }
+        if ($maxZ -lt 100) { continue }  # ocean floor — skip
+        $li = [string]$c.l
+        $land = $meta.landscapes[$c.l]
+        $scale = if ($land.sx -gt 0) { [double]$land.sx } else { 100.0 }
+        $step = if ($landSteps.ContainsKey($li)) { [double]$landSteps[$li] } else { 255.0 }
+        $compW = $step * $scale
+        $minZ = if ($null -ne $c.minZ) { [double]$c.minZ } else { 0.0 }
+        $comps.Add([PSCustomObject]@{
+            wx = [double]$c.wx
+            wy = [double]$c.wy
+            wx2 = [double]$c.wx + $compW
+            wy2 = [double]$c.wy + $compW
+            res = [int]$c.res
+            minZ = $minZ
+            maxZ = $maxZ
+            f = [string]$c.f
+        }) | Out-Null
+    }
+    $script:TerrainLandComps = $comps
+    $script:TerrainCacheReady = $true
+    return $true
+}
+
+function Get-TerrainHeightAt($DataDir, [double]$WorldX, [double]$WorldY) {
+    if (-not (Initialize-TerrainCache $DataDir)) { return $null }
+    foreach ($c in $script:TerrainLandComps) {
+        if ($WorldX -ge $c.wx -and $WorldX -lt $c.wx2 -and $WorldY -ge $c.wy -and $WorldY -lt $c.wy2) {
+            $hfPath = Join-Path $DataDir "heightmaps\$($c.f)"
+            if (-not (Test-Path -LiteralPath $hfPath)) { return $null }
+            try {
+                $bytes = [System.IO.File]::ReadAllBytes($hfPath)
+                if ($bytes.Length -lt 8) { return $null }
+                $res = [BitConverter]::ToInt32($bytes, 0)
+                if ($res -le 0 -or $res -ne $c.res) { return $null }
+                $compW = $c.wx2 - $c.wx
+                $fx = ($WorldX - $c.wx) / $compW
+                $fy = ($WorldY - $c.wy) / $compW
+                $hx = [int][Math]::Floor($fx * $res)
+                $hy = [int][Math]::Floor($fy * $res)
+                if ($hx -lt 0) { $hx = 0 } elseif ($hx -ge $res) { $hx = $res - 1 }
+                if ($hy -lt 0) { $hy = 0 } elseif ($hy -ge $res) { $hy = $res - 1 }
+                $byteOff = 4 + ($hy * $res + $hx) * 2
+                if ($byteOff + 1 -ge $bytes.Length) { return $null }
+                $raw = [BitConverter]::ToUInt16($bytes, $byteOff)
+                $z = $c.minZ + ($raw / 65535.0) * ($c.maxZ - $c.minZ)
+                return $z
+            } catch { return $null }
+        }
+    }
+    return $null
+}
+
 function Get-RconWorkerDiagnostic($spoolDir, $cmdPath) {
     $statusPath = Join-Path $dataDir "rcon_status.json"
     $now = [long][DateTimeOffset]::UtcNow.ToUnixTimeSeconds()
@@ -715,6 +805,7 @@ try {
                         @{name="wp.speed"; usage="wp.speed [player] <mult>"; description="Set movement speed"; category="admin"},
                         @{name="wp.jump"; usage="wp.jump [player] <mult>"; description="Set jump height (1.0=normal, 2.0=double)"; category="admin"},
                         @{name="wp.gravity"; usage="wp.gravity [player] <mult>"; description="Set gravity (1.0=normal, 0.3=moon)"; category="admin"},
+                        @{name="wp.tp"; usage="wp.tp [player] <x> <y> [z]"; description="Teleport player to absolute world coordinates"; category="admin"},
                         @{name="wp.time"; usage="wp.time"; description="Read current time of day"; category="world"},
                         @{name="wp.creatures"; usage="wp.creatures"; description="Count spawned creatures by type"; category="world"},
                         @{name="wp.entities"; usage="wp.entities"; description="Count entities by type"; category="world"},
@@ -741,6 +832,29 @@ try {
                         Send-Json $context @{
                             error = "Map not ready yet. Join the server once to auto-generate the map."
                             generation = $generation
+                        }
+                    }
+                }
+                "/api/terrain_height" {
+                    # Sample the exported heightmap at a world (X, Y) and return ground Z.
+                    # Used by the SEA CHART click-to-teleport so we don't drop the player
+                    # under a mountain or in deep water.
+                    $qs = $context.Request.QueryString
+                    $xRaw = $qs["x"]
+                    $yRaw = $qs["y"]
+                    $worldX = 0.0; $worldY = 0.0
+                    if ([string]::IsNullOrWhiteSpace($xRaw) -or [string]::IsNullOrWhiteSpace($yRaw)) {
+                        Send-Json $context @{ error = "x and y query params required" } 400
+                    } elseif (-not [double]::TryParse($xRaw, [ref]$worldX)) {
+                        Send-Json $context @{ error = "x must be numeric" } 400
+                    } elseif (-not [double]::TryParse($yRaw, [ref]$worldY)) {
+                        Send-Json $context @{ error = "y must be numeric" } 400
+                    } else {
+                        $z = Get-TerrainHeightAt -DataDir $dataDir -WorldX $worldX -WorldY $worldY
+                        if ($null -eq $z) {
+                            Send-Json $context @{ x = $worldX; y = $worldY; z = $null; reason = "no_land_data" }
+                        } else {
+                            Send-Json $context @{ x = $worldX; y = $worldY; z = [double]$z }
                         }
                     }
                 }


### PR DESCRIPTION
## What this adds

A click-to-teleport workflow that ships across three layers:

### 1. `wp.tp [player] <x> <y> [z]` admin command (`admin.lua`)

Per-player teleport to absolute world coordinates. Calls `K2_SetActorLocation(loc, false, {}, true)` — the `bTeleport=true` flag routes through the same discontinuous-move path Windrose already uses for the bell-recall mechanic, so anti-cheat / replication doesn't rubber-band the move. Z is optional; if omitted, the player's current Z is preserved (good for short hops; the dashboard supplies a sampled Z for cross-map clicks).

Same multi-word-name parsing as `wp.speed` / `wp.jump` / `wp.gravity` — trailing 2 or 3 numeric args are coords, everything before is the (possibly multi-word) player name.

After a successful teleport the handler calls `LiveMap.forceWrite()` so the new player position is pushed to `livemap_data.json` immediately rather than waiting up to 5 s for the next interval. Keeps the click-to-teleport UI snappy without forcing a faster default LiveMap interval on every server.

### 2. `/api/terrain_height?x=&y=` endpoint (`server/windrose_plus_server.ps1`)

Samples the heightmap data already on disk (`terrain_v17.json` plus the per-component uint16 `.bin` files written by `HeightmapExporter`) at any world (X, Y) and returns ground Z.

- Manifest parsed once, cached in script scope
- Per-request: linear scan over ~1k land components + one ~50 KB file read
- Components with `maxZ < 100` (ocean floor, per `generateTiles.ps1`'s threshold) are filtered out — clicks over open water return `{ z: null }` rather than dropping the player on the seabed

### 3. TELEPORT button per player row + click flow (`server/web/index.html`)

Cinzel/uppercase styling matches the existing CONSOLE / SEA CHART / SAILING tabs. Clicking TELEPORT:
- auto-switches to the SEA CHART tab if not already there
- adds a crosshair cursor over the map
- shows a hint banner at the top (`Click the map to teleport <name> (X, Y) — ESC to cancel`)
- mirrors the live cursor world coords into the player row's coords field in italic accent, so the admin sees exactly where the click would land before committing

Click commits the teleport. ESC or click-same-button cancels.

## Z policy in the click handler

The `/api/terrain_height` sample is only the start; the JS click handler applies a small offset before sending `wp.tp`:

| Terrain at click | Offset / clamp | Why |
|---|---|---|
| `Z >= 0` (dry land) | `terrain + 100 cm` | ~1 m above ground — small enough that the player doesn't visibly drop onto grass |
| `Z < 0` (shoreline / underwater) | clamp to `Z = 300 cm` | Pawn capsule extends below the feet pivot and the water shaders make even +1 m above sea level look "in water"; 3 m gives a clean float |
| Endpoint returns `z: null` | omit Z | `wp.tp` preserves current Z, same behavior as a Z-less call from RCON |

## Bundled bug fix: on-ship player/pawn positions

While testing this PR, on-ship players consistently rendered at `(0, 0)` on the SEA CHART. Diagnosed:

`Query.getPlayers()` and `LiveMap`'s mob/node iteration both read positions via `pawn.ReplicatedMovement.Location`. When the pawn is attached to a moving parent (boarded a ship, riding a mount), that field stops giving world coords and reads `(0, 0, 0)`. AI ships and crew on those ships are affected the same way.

Switched the primary read to `K2_GetActorLocation()` (which traverses the attachment hierarchy and returns true world coords), with `ReplicatedMovement.Location` retained as a fallback. Three call sites: player-position read, mob/ship pawn read, mineral-node read. Folded into this PR because the click-to-teleport accuracy directly depends on the player marker showing where they actually are.

## What got tested end-to-end

On Windrose 0.10.0.3.104 with this branch's exact files:

- Mountain click → `Z = 2441` sampled, lands cleanly on the peak
- Open ocean (deep water) → endpoint returns null **or** clamps to 300, player floats above water, no drown / swim animation
- Shoreline → terrain near sea level → player wades on beach (gravity settles them at the actual sand elevation; this is accepted as v1 behavior — clicking slightly inland gives dry land)
- Multi-player render → every online player gets a TELEPORT button; armed state cleanly switches between players if you click another player's button before clicking the map
- Live preview survives the 5-second `/api/status` refresh while hovering (preview state preserved across re-renders)
- ESC anywhere disarms cleanly; click-same-button toggles off; cursor leaves map → row coords revert immediately

## Things considered and intentionally *not* in this PR

- **LiveMap interval changes.** Earlier revisions of this branch lowered `_playerInterval` to 1 s and the dashboard poll to 1000 ms. Reverted per maintainer review — uses the post-v1.1.6 defaults (player=5 s, entity=30 s, dashboard poll=5000 ms). The `forceWrite()` call after `wp.tp` provides the snappy interactive feel without paying the per-server cost of faster default intervals.
- **Smart shoreline snap.** If terrain is near sea level, search a small radius for the nearest dry-land cell. Considered, deferred — the current behavior is internally consistent and clicking slightly inland is a valid workaround. Could be a follow-up.
- **Confirmation dialog before teleport.** `wp.tp` is reversible (you can teleport back), the live preview gives the admin a clear pre-commit view of the target, and the existing RCON line in the console doubles as an audit trail. A modal felt like added friction.
- **Player-side consent.** Currently the targeted player has no notification / refusal path. Admin-only feature, fine for v1; happy to revisit if you'd like.

## File-level diff summary (vs `main`)

```
admin.lua                       +92
query.lua                       +12 / -1
livemap.lua                     +19 / -3
server/windrose_plus_server.ps1 +114
server/web/index.html           +269 / -3
                                ─────
                                +506 / -7 across 5 files
```

No new dependencies, no schema migrations, no config changes. PowerShell parses clean (validated with `[Parser]::ParseFile`).
