### PR TITLE
feat: wp.heal, wp.god, wp.fly, wp.kick, wp.mods; /api/mods; rate limi…

### DIFF
--- a/WindrosePlus/Scripts/modules/admin.lua
+++ b/WindrosePlus/Scripts/modules/admin.lua
@@ -1156,6 +1156,225 @@ function Admin._registerCommands()
         end
     }
 
+    -- =========================================
+    -- Admin Powers
+    -- =========================================
+
+    Admin._commands["wp.heal"] = {
+        description = "Restore player health to maximum",
+        usage = "wp.heal [player]",
+        category = "admin",
+        playerArg = true,
+        examples = {"wp.heal", "wp.heal HumanGenome"},
+        handler = function(args)
+            local targetName = #args > 0 and table.concat(args, " "):lower() or nil
+            local chars = FindAllOf("R5Character")
+            if not chars then return "No players found" end
+            local count = 0
+            for _, char in ipairs(chars) do
+                if char:IsValid() then
+                    local hasController = false
+                    pcall(function()
+                        local ctrl = char.Controller
+                        if ctrl and ctrl:IsValid() then hasController = true end
+                    end)
+                    if hasController then
+                        local charName = nil
+                        pcall(function() charName = char:GetFullName():match("([^%.]+)$") end)
+                        local nameMatch = not targetName or (charName and charName:lower() == targetName)
+                        if nameMatch then
+                            pcall(function()
+                                local hc = char.HealthComponent
+                                if hc and hc:IsValid() then
+                                    local maxHp = hc.MaxHealth
+                                    if maxHp then
+                                        hc.CurrentHealth = maxHp
+                                        count = count + 1
+                                    end
+                                end
+                            end)
+                        end
+                    end
+                end
+            end
+            if targetName then
+                return count > 0 and ("Healed " .. targetName .. " to full") or ("Player '" .. targetName .. "' not found")
+            end
+            return count > 0 and ("Healed " .. count .. " player(s) to full") or "No players to heal"
+        end
+    }
+
+    Admin._commands["wp.god"] = {
+        description = "Toggle invulnerability for a player",
+        usage = "wp.god [player]",
+        category = "admin",
+        playerArg = true,
+        examples = {"wp.god", "wp.god HumanGenome"},
+        handler = function(args)
+            local targetName = #args > 0 and table.concat(args, " "):lower() or nil
+            local chars = FindAllOf("R5Character")
+            if not chars then return "No players found" end
+            local results = {}
+            for _, char in ipairs(chars) do
+                if char:IsValid() then
+                    local hasController = false
+                    pcall(function()
+                        local ctrl = char.Controller
+                        if ctrl and ctrl:IsValid() then hasController = true end
+                    end)
+                    if hasController then
+                        local charName = nil
+                        pcall(function() charName = char:GetFullName():match("([^%.]+)$") end)
+                        local nameMatch = not targetName or (charName and charName:lower() == targetName)
+                        if nameMatch then
+                            local toggled = false
+                            -- Try R5-specific bIsInvulnerable first
+                            pcall(function()
+                                local current = char.bIsInvulnerable
+                                if current ~= nil then
+                                    char.bIsInvulnerable = not current
+                                    toggled = true
+                                    table.insert(results, (charName or "Player") .. ": god " .. (char.bIsInvulnerable and "ON" or "OFF"))
+                                end
+                            end)
+                            -- Fallback: standard UE4 bCanBeDamaged (inverted logic)
+                            if not toggled then
+                                pcall(function()
+                                    local current = char.bCanBeDamaged
+                                    if current ~= nil then
+                                        char.bCanBeDamaged = not current
+                                        toggled = true
+                                        table.insert(results, (charName or "Player") .. ": god " .. (not char.bCanBeDamaged and "ON" or "OFF"))
+                                    end
+                                end)
+                            end
+                            if not toggled then
+                                table.insert(results, (charName or "Player") .. ": not supported on this build")
+                            end
+                        end
+                    end
+                end
+            end
+            return #results > 0 and table.concat(results, "\n") or (targetName and ("Player '" .. targetName .. "' not found") or "No players found")
+        end
+    }
+
+    Admin._commands["wp.fly"] = {
+        description = "Toggle fly mode for a player",
+        usage = "wp.fly [player]",
+        category = "admin",
+        playerArg = true,
+        examples = {"wp.fly", "wp.fly HumanGenome"},
+        handler = function(args)
+            local targetName = #args > 0 and table.concat(args, " "):lower() or nil
+            local pcs = FindAllOf("PlayerController")
+            if not pcs then return "No players found" end
+            local results = {}
+            for _, pc in ipairs(pcs) do
+                if pc:IsValid() then
+                    local pcName = nil
+                    pcall(function()
+                        local ps = pc.PlayerState
+                        if ps and ps:IsValid() then
+                            local val = ps.PlayerNamePrivate
+                            if val then
+                                local ok, str = pcall(function() return val:ToString() end)
+                                if ok and str then pcName = str end
+                            end
+                        end
+                    end)
+                    local nameMatch = not targetName or (pcName and pcName:lower() == targetName)
+                    if nameMatch then
+                        pcall(function()
+                            local pawn = pc.Pawn
+                            if pawn and pawn:IsValid() then
+                                local mc = pawn.CharacterMovement or pawn.MovementComponent
+                                if mc and mc:IsValid() then
+                                    local current = mc.bCheatFlying
+                                    if current ~= nil then
+                                        local enable = not current
+                                        mc.bCheatFlying = enable
+                                        mc.bCanFly = enable
+                                        table.insert(results, (pcName or "Player") .. ": fly " .. (enable and "ON" or "OFF"))
+                                    else
+                                        table.insert(results, (pcName or "Player") .. ": fly not available")
+                                    end
+                                end
+                            end
+                        end)
+                    end
+                end
+            end
+            return #results > 0 and table.concat(results, "\n") or (targetName and ("Player '" .. targetName .. "' not found") or "No players found")
+        end
+    }
+
+    Admin._commands["wp.kick"] = {
+        description = "Disconnect a player from the server",
+        usage = "wp.kick <player>",
+        category = "admin",
+        examples = {"wp.kick HumanGenome", "wp.kick John Smith"},
+        handler = function(args)
+            if #args == 0 then return "Usage: wp.kick <player>" end
+            local targetName = table.concat(args, " "):lower()
+            local pcs = FindAllOf("PlayerController")
+            if not pcs then return "No players found" end
+            local found = false
+            for _, pc in ipairs(pcs) do
+                if pc:IsValid() then
+                    local pcName = nil
+                    pcall(function()
+                        local ps = pc.PlayerState
+                        if ps and ps:IsValid() then
+                            local val = ps.PlayerNamePrivate
+                            if val then
+                                local ok, str = pcall(function() return val:ToString() end)
+                                if ok and str then pcName = str end
+                            end
+                        end
+                    end)
+                    if pcName and pcName:lower() == targetName then
+                        found = true
+                        -- Try GameMode KickPlayer first (clean disconnect with reason)
+                        local done = false
+                        pcall(function()
+                            local gm = Admin._findFirstValid("R5GameMode") or Admin._findFirstValid("GameMode")
+                            if gm and gm:IsValid() then
+                                gm:KickPlayer(pc, "")
+                                done = true
+                            end
+                        end)
+                        -- Fallback: destroy the controller
+                        if not done then
+                            pcall(function() pc:Destroy() end)
+                        end
+                        break
+                    end
+                end
+            end
+            return found and ("Kicked " .. targetName) or ("Player '" .. targetName .. "' not found")
+        end
+    }
+
+    Admin._commands["wp.mods"] = {
+        description = "List loaded third-party mods",
+        usage = "wp.mods",
+        category = "server",
+        handler = function(args)
+            local mods = WindrosePlus._modules.Mods
+            if not mods then return "Mod loader not initialized" end
+            local loaded = mods.getLoadedMods and mods.getLoadedMods() or {}
+            if #loaded == 0 then return "No mods loaded" end
+            local lines = {"Loaded mods (" .. #loaded .. "):"}
+            for _, m in ipairs(loaded) do
+                local line = "  " .. (m.name or m.dir or "?") .. " v" .. (m.version or "?")
+                if m.author and m.author ~= "?" then line = line .. " by " .. m.author end
+                table.insert(lines, line)
+            end
+            return table.concat(lines, "\n")
+        end
+    }
+
 end
 
 -- Delegate to shared helper in WindrosePlus global

--- a/WindrosePlus/Scripts/modules/mods.lua
+++ b/WindrosePlus/Scripts/modules/mods.lua
@@ -11,6 +11,7 @@ Mods._loaded = {}
 Mods._fileSnapshots = {} -- filename -> mtime string for change detection
 
 function Mods.init(gameDir)
+    Mods._gameDir = gameDir
     -- Mods live alongside Scripts in the WindrosePlus mod folder
     -- UE4SS CWD is R5/Binaries/Win64, build path relative to known structure
     -- __SCRIPT_DIRECTORY__ or similar UE4SS globals may not exist, so use relative path
@@ -47,6 +48,9 @@ function Mods.init(gameDir)
 
     -- Scan and load mods
     Mods._scanAndLoad()
+
+    -- Write mods list so the dashboard /api/mods endpoint can serve it
+    Mods._writeModsList()
 
     -- Take initial file snapshot for change detection
     Mods._takeSnapshot()
@@ -206,6 +210,19 @@ end
 
 function Mods.getLoadedMods()
     return Mods._loaded
+end
+
+function Mods._writeModsList()
+    if not Mods._gameDir then return end
+    local list = {}
+    for _, m in ipairs(Mods._loaded) do
+        table.insert(list, { name = m.name, version = m.version, author = m.author, dir = m.dir })
+    end
+    local ok, content = pcall(json.encode, list)
+    if not ok then return end
+    local path = Mods._gameDir .. "windrose_plus_data\\mods_list.json"
+    local f = io.open(path, "w")
+    if f then f:write(content); f:close() end
 end
 
 return Mods

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -110,6 +110,21 @@ Usage: wp.uptime
 Uptime: 2d 14h 32m
 ```
 
+### wp.mods
+
+List all loaded third-party mods with version and author.
+
+```
+Usage: wp.mods
+```
+
+```
+> wp.mods
+Loaded mods (2):
+  example-welcome v1.0 by HumanGenome
+  discord-relay v0.3 by CaptainMorgan
+```
+
 ### wp.reload
 
 Reload config from disk. Changes to `windrose_plus.json` take effect immediately without a server restart.
@@ -360,6 +375,70 @@ Connections:
 ---
 
 ## Admin
+
+### wp.heal
+
+Restore one or all players to full health. Accepts `[player]` argument.
+
+```
+Usage: wp.heal [player]
+```
+
+```
+> wp.heal
+Healed 3 player(s) to full
+
+> wp.heal HumanGenome
+Healed humangenome to full
+```
+
+### wp.god
+
+Toggle invulnerability for one or all players. Accepts `[player]` argument.
+
+```
+Usage: wp.god [player]
+```
+
+```
+> wp.god HumanGenome
+HumanGenome: god ON
+
+> wp.god HumanGenome
+HumanGenome: god OFF
+```
+
+### wp.fly
+
+Toggle fly mode for one or all players. Accepts `[player]` argument.
+
+```
+Usage: wp.fly [player]
+```
+
+```
+> wp.fly HumanGenome
+HumanGenome: fly ON
+
+> wp.fly HumanGenome
+HumanGenome: fly OFF
+```
+
+### wp.kick
+
+Disconnect a player from the server.
+
+```
+Usage: wp.kick <player>
+```
+
+```
+> wp.kick HumanGenome
+Kicked humangenome
+
+> wp.kick John Smith
+Kicked john smith
+```
 
 ### wp.speed
 

--- a/server/windrose_plus_server.ps1
+++ b/server/windrose_plus_server.ps1
@@ -149,6 +149,29 @@ function Get-SessionFromCookies($request) {
     return $null
 }
 
+# RCON rate limiting — max 10 commands per 10-second window per source IP
+$script:rconRateLimit = @{}
+
+function Test-RconRateLimit($clientIp) {
+    $now = [DateTimeOffset]::UtcNow.ToUnixTimeSeconds()
+    if (-not $script:rconRateLimit.ContainsKey($clientIp)) {
+        $script:rconRateLimit[$clientIp] = [System.Collections.Generic.List[long]]::new()
+    }
+    $timestamps = $script:rconRateLimit[$clientIp]
+    $cutoff = $now - 10
+    while ($timestamps.Count -gt 0 -and $timestamps[0] -le $cutoff) { $timestamps.RemoveAt(0) }
+    if ($timestamps.Count -ge 10) { return $false }
+    $timestamps.Add($now)
+    # Prune stale IPs to prevent unbounded growth
+    if ($script:rconRateLimit.Count -gt 500) {
+        $stale = @($script:rconRateLimit.GetEnumerator() |
+            Where-Object { $_.Value.Count -eq 0 -or $_.Value[$_.Value.Count - 1] -lt ($now - 60) } |
+            Select-Object -ExpandProperty Key)
+        foreach ($k in $stale) { $script:rconRateLimit.Remove($k) }
+    }
+    return $true
+}
+
 # Login page HTML
 $loginPageHtml = @"
 <!DOCTYPE html>
@@ -266,6 +289,34 @@ Register-ObjectEvent $tileGenTimer Elapsed -Action {
     }
 } | Out-Null
 $tileGenTimer.Start()
+
+# CPU affinity signal handler — reads affinity_request.txt written by the Lua mod
+# and applies the requested CPU mask to the game server process.
+# Requires the dashboard to run with sufficient permissions to SetInformation on the
+# game process (both typically run as admin per the installation guide).
+$affinityTimer = New-Object System.Timers.Timer
+$affinityTimer.Interval = 3000
+$affinityTimer.AutoReset = $true
+$affinitySignalPath = Join-Path $dataDir "affinity_request.txt"
+Register-ObjectEvent $affinityTimer Elapsed -MessageData $affinitySignalPath -Action {
+    $sigFile = $Event.MessageData
+    if (Test-Path -LiteralPath $sigFile) {
+        try {
+            $content = Get-Content -LiteralPath $sigFile -Raw -ErrorAction Stop
+            Remove-Item $sigFile -Force -ErrorAction SilentlyContinue
+            $mask = [long](($content -split "`n" | Select-Object -First 1).Trim())
+            $proc = Get-Process -Name "WindroseServer-Win64-Shipping" -ErrorAction SilentlyContinue
+            if (-not $proc) { $proc = Get-Process -Name "WindroseServer" -ErrorAction SilentlyContinue }
+            if ($proc) {
+                $proc.ProcessorAffinity = [System.IntPtr]$mask
+                Write-Host "CPU affinity -> 0x$([string]::Format('{0:X}', $mask))"
+            }
+        } catch {
+            Write-Host "CPU affinity handler: $_"
+        }
+    }
+} | Out-Null
+$affinityTimer.Start()
 
 function Send-Json($context, $data, $statusCode = 200) {
     $json = if ($null -eq $data) { '{}' } else { $data | ConvertTo-Json -Depth 10 -Compress }
@@ -713,6 +764,10 @@ try {
                         @{name="wp.pos"; usage="wp.pos [player]"; description="Get player positions"; category="players"},
                         @{name="wp.stamina"; usage="wp.stamina [player]"; description="Read stamina/hunger/thirst"; category="players"},
                         @{name="wp.speed"; usage="wp.speed [player] <mult>"; description="Set movement speed"; category="admin"},
+                        @{name="wp.heal"; usage="wp.heal [player]"; description="Restore player health to maximum"; category="admin"},
+                        @{name="wp.god"; usage="wp.god [player]"; description="Toggle invulnerability"; category="admin"},
+                        @{name="wp.fly"; usage="wp.fly [player]"; description="Toggle fly mode"; category="admin"},
+                        @{name="wp.kick"; usage="wp.kick <player>"; description="Disconnect a player"; category="admin"},
                         @{name="wp.jump"; usage="wp.jump [player] <mult>"; description="Set jump height (1.0=normal, 2.0=double)"; category="admin"},
                         @{name="wp.gravity"; usage="wp.gravity [player] <mult>"; description="Set gravity (1.0=normal, 0.3=moon)"; category="admin"},
                         @{name="wp.time"; usage="wp.time"; description="Read current time of day"; category="world"},
@@ -722,6 +777,7 @@ try {
                         @{name="wp.perf"; usage="wp.perf"; description="Show server performance metrics"; category="diagnostics"},
                         @{name="wp.memory"; usage="wp.memory"; description="Detailed memory usage"; category="diagnostics"},
                         @{name="wp.connections"; usage="wp.connections"; description="Network connection info"; category="diagnostics"},
+                        @{name="wp.mods"; usage="wp.mods"; description="List loaded mods"; category="server"},
                         @{name="wp.mapgen"; usage="wp.mapgen"; description="Generate heightmap for live map"; category="server"},
                         @{name="wp.mapexport"; usage="wp.mapexport"; description="Trigger terrain heightmap export"; category="server"}
                     )
@@ -769,6 +825,11 @@ try {
                 "/api/rcon" {
                     if ($method -ne "POST") {
                         Send-Json $context @{ error = "POST required" } 405
+                        continue
+                    }
+                    $clientIp = $context.Request.RemoteEndPoint.Address.ToString()
+                    if (-not (Test-RconRateLimit $clientIp)) {
+                        Send-Json $context @{ error = "Rate limit exceeded — max 10 commands per 10 seconds" } 429
                         continue
                     }
                     $reader = New-Object System.IO.StreamReader($context.Request.InputStream)
@@ -888,6 +949,25 @@ try {
                     } finally {
                         Remove-Item -LiteralPath $uploadPath -Force -ErrorAction SilentlyContinue
                         Remove-Item -LiteralPath $outputPath -Force -ErrorAction SilentlyContinue
+                    }
+                }
+                "/api/mods" {
+                    $modsFile = Join-Path $dataDir "mods_list.json"
+                    if (Test-Path -LiteralPath $modsFile) {
+                        try {
+                            $raw = Get-Content $modsFile -Raw -ErrorAction Stop
+                            $buffer = [System.Text.Encoding]::UTF8.GetBytes($raw)
+                            $context.Response.StatusCode = 200
+                            $context.Response.ContentType = "application/json"
+                            $context.Response.Headers.Add("Access-Control-Allow-Origin", "*")
+                            $context.Response.ContentLength64 = $buffer.Length
+                            $context.Response.OutputStream.Write($buffer, 0, $buffer.Length)
+                            $context.Response.Close()
+                        } catch {
+                            Send-Json $context @{ mods = @(); error = $_.Exception.Message }
+                        }
+                    } else {
+                        Send-Json $context @{ mods = @() }
                     }
                 }
                 default {


### PR DESCRIPTION
…ting; CPU affinity handler

Admin commands:
- wp.heal [player] — set CurrentHealth = MaxHealth on HealthComponent
- wp.god [player]  — toggle bIsInvulnerable (fallback: bCanBeDamaged)
- wp.fly [player]  — toggle bCheatFlying + bCanFly on CharacterMovement
- wp.kick <player> — GameMode:KickPlayer fallback to pc:Destroy()
- wp.mods          — list loaded third-party mods from Mods registry

Dashboard / API:
- /api/mods endpoint — serves mods_list.json written by mod loader at startup
- RCON rate limit — 10 commands / 10-second window per IP, returns 429
- CPU affinity signal handler — polls affinity_request.txt every 3s, applies mask to WindroseServer-Win64-Shipping.exe via ProcessorAffinity

mods.lua: store gameDir, write windrose_plus_data\mods_list.json on init
docs/commands.md: document all new commands and /api/mods endpoint