### PR TITLE
Fix dedicated server player tracking & dashboard failure (#47)

### DIFF
--- a/WindrosePlus/Scripts/modules/admin.lua
+++ b/WindrosePlus/Scripts/modules/admin.lua
@@ -31,6 +31,13 @@ function Admin.execute(command, args)
     end
     local ok, result = pcall(cmd.handler, args)
     if ok then
+        -- Force immediate JSON writes so the dashboard reads fresh data
+        -- after any RCON command. Resolve modules via _modules at call time
+        -- to survive Lua GC / RestartMod. See #47.
+        local Q = WindrosePlus and WindrosePlus._modules and WindrosePlus._modules.Query
+        local LM = WindrosePlus and WindrosePlus._modules and WindrosePlus._modules.LiveMap
+        if Q and Q.forceWrite then pcall(Q.forceWrite) end
+        if LM and LM.forceWrite then pcall(LM.forceWrite) end
         return "ok", result or "OK"
     else
         return "error", tostring(result)

--- a/WindrosePlus/Scripts/modules/livemap.lua
+++ b/WindrosePlus/Scripts/modules/livemap.lua
@@ -176,4 +176,12 @@ function LiveMap._collectAndWrite(collectEntities, prefetchedPlayers)
     os.rename(LiveMap._tmpPath, LiveMap._path)
 end
 
+-- Force an immediate write (used by RCON commands so dashboards update promptly)
+function LiveMap.forceWrite()
+    LiveMap._lastPlayerWrite = os.time()
+    LiveMap._lastEntityWrite = os.time()
+    LiveMap._wroteEmpty = false
+    LiveMap._collectAndWrite(true, nil)
+end
+
 return LiveMap


### PR DESCRIPTION
## Summary
- Add `LiveMap.forceWrite()` to match the existing `Query.forceWrite()` pattern, enabling immediate JSON writes when triggered by RCON commands
- Trigger `forceWrite` for both Query and LiveMap after every RCON command in `Admin.execute()`, resolving modules via `_modules` at call time to survive Lua GC / RestartMod

## Why
On UE 5.6.1 dedicated servers, `server_status.json` and `livemap_data.json` stayed stale even after `wp.players` / `wp.status` commands were executed. The dashboard read outdated `player_count: 0` data because:

1. `livemap.lua` had no `forceWrite()` function at all
2. `admin.lua` did not force-refresh JSON files after command execution

This ensures both files are refreshed promptly after any admin command, fixing the "Windrose+ not responding" banner and 0-player display on dedicated server dashboards.

## Changes
- `WindrosePlus/Scripts/modules/livemap.lua` — Added `LiveMap.forceWrite()` (mirrors `Query.forceWrite()` at `query.lua:61-64`)
- `WindrosePlus/Scripts/modules/admin.lua` — Added forceWrite calls in `Admin.execute()` after successful command execution

Fixes #47