### PR TITLE
Add degraded EIGT starvation fallback (#46)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## [1.1.7] - 2026-04-29
+
+Targets [#46](https://github.com/HumanGenome/WindrosePlus/issues/46) and the same dashboard-stale reports in [#47](https://github.com/HumanGenome/WindrosePlus/issues/47). Affected hosts boot Windrose+ v1.1.6 cleanly, keep the RCON loop alive, and keep writing `tick.beat`, but `server_status.json` and `livemap_data.json` never appear. @kohanis instrumented the dispatcher and confirmed the key failure mode: `pcall(ExecuteInGameThread, fn)` returns `ok=true`, but the queued closure body never runs. That leaves `mode` stuck on `boot` and the dashboard waiting for a server ledger forever.
+
+### Fixed
+
+- **Degraded snapshots for starved `ExecuteInGameThread` queues.** `dispatchTick` now requires two consecutive stale observations before declaring a writer starved. When that happens, Query and LiveMap no longer run their UObject-reading collectors on the async RCON thread. Instead, they write file-only degraded snapshots with `degraded=true`, `mode="degraded"` for status, `degraded_reason="execute_in_game_thread_starved"`, and `cache_age_sec` when a last-known good snapshot exists. If no good snapshot was ever written, the fallback writes an empty no-UObject snapshot so dashboards stop showing "Awaiting server ledger" indefinitely.
+- **Stale queued closures are cancelled.** Each writer dispatch carries a generation token. Once a writer enters degraded mode, any old `ExecuteInGameThread` closure that eventually drains sees the generation mismatch and returns without writing over the degraded snapshot.
+- **POIScan and third-party tick callbacks stay safe.** POIScan is suppressed in degraded mode instead of walking actors off-thread. `runModTicks` is excluded from the degraded fallback entirely, so third-party callbacks registered through `WindrosePlus.API.registerTickCallback` keep the original game-thread semantics. If the UE4SS queue is starved, those callbacks resume only if the queue starts draining again or the server is restarted.
+- **Added `LiveMap.forceWrite()`.** The force-write helper from @brazerZa's #48 contribution is included for future dashboard/API refresh flows; the RCON-command callsite from that PR is intentionally not included because it would still collect UObjects from the async thread on affected hosts.
+
 ## [1.1.6] - 2026-04-28
 
 Targeted at the server-stutter cohort tracked in [#33](https://github.com/HumanGenome/WindrosePlus/issues/33). Eight-plus self-hosted operators have reported game-thread stutter / rubber-banding when 2+ players are online; @James-Wilkinson narrowed the cause with a controlled experiment on GPortal — disabling the runtime mod after applying multipliers eliminated the lag while leaving the PAK patches in place, proving the writer dispatch path was the culprit. This release reduces the per-tick cost via interval relaxation and gives constrained hosts an explicit lever to disable individual writers.

--- a/WindrosePlus/Scripts/main.lua
+++ b/WindrosePlus/Scripts/main.lua
@@ -527,39 +527,88 @@ end
 -- the game thread), skip queuing another one. Prevents unbounded action-vector
 -- growth when the game thread is momentarily slow.
 --
--- Idle-server starvation guard: on a dedicated server with no players, the
--- game thread ticks very slowly and ExecuteInGameThread queues can sit
--- undrained for minutes. If a pending dispatch is older than the stale
--- threshold, force-clear and run the function directly on the async thread.
--- In idle mode the writers do effectively zero UObject reads (no players, no
--- scanning), so the original game-thread race risk doesn't apply.
+-- Queue-starvation guard: on some UE4SS/R5 combinations, ExecuteInGameThread
+-- accepts a closure but never drains it (#46). The fallback below never runs a
+-- UObject-reading writer on the async thread. Query and LiveMap emit degraded
+-- file-only snapshots, POIScan is suppressed, and third-party mod ticks stay on
+-- the original game-thread path.
 local _pendingTicks = {}
 local _pendingSince = {}
-local _stalePendingSeconds = 30
+local _consecutiveStales = {}
+local _degraded = {}
+local _generation = {}
+local _stalePendingSeconds = 10
+local _stalePendingRequired = 2
+local _degradableWriters = { Query = true, LiveMap = true, POIScan = true }
 
-local function dispatchTick(fn)
+-- UE4SS enters one Lua VM for this mod. These dispatch tables are only touched
+-- from Lua callbacks in that VM; the generation token protects against late
+-- game-thread closures after the async loop has dropped or degraded a pending
+-- dispatch.
+local function _writerModule(name)
+    return WindrosePlus and WindrosePlus._modules and WindrosePlus._modules[name] or nil
+end
+
+local function _writeDegraded(name)
+    local reason = "execute_in_game_thread_starved"
+    if name == "Query" then
+        local m = _writerModule("Query")
+        if m and m.writeDegraded then pcall(m.writeDegraded, reason) end
+    elseif name == "LiveMap" then
+        local m = _writerModule("LiveMap")
+        if m and m.writeDegraded then pcall(m.writeDegraded, reason) end
+    end
+end
+
+local function _enterDegraded(key, name)
+    _pendingTicks[key] = nil
+    _pendingSince[key] = nil
+    _consecutiveStales[key] = 0
+    _degraded[key] = true
+    _generation[key] = (_generation[key] or 0) + 1
+    if name == "POIScan" then
+        Log.warn("Core", "ExecuteInGameThread queue starved (#46) — POIScan suppressed in degraded mode")
+    else
+        Log.warn("Core", "ExecuteInGameThread queue starved (#46) — " .. tostring(name) .. " in degraded mode")
+        _writeDegraded(name)
+    end
+end
+
+local function dispatchTick(fn, name)
     -- Tick callbacks resolve their target lazily through WindrosePlus._modules.
     -- A failed module init or a Lua GC pass on a captured upvalue can land us
     -- here with fn=nil; pcall(nil) raises LUA_ERRRUN and escapes UE4SS as a
     -- STATUS_FATAL_USER_CALLBACK_EXCEPTION. Guarding here is cheap insurance.
     if type(fn) ~= "function" then return end
+    local key = name or fn
     if not _hasExecuteInGameThread then
         pcall(fn)
         return
     end
-    if _pendingTicks[fn] then
-        local age = os.time() - (_pendingSince[fn] or 0)
-        if age < _stalePendingSeconds then return end
-        -- Queue starved — drop the entry and wait for the next LoopAsync cycle.
-        -- Running the writer here on the async thread can race UE GC if mode
-        -- has been falsely set to "active" by a non-player pawn (see #43), so
-        -- we trade a delayed write for crash safety.
-        _pendingTicks[fn] = nil
-        _pendingSince[fn] = nil
+    if _degraded[key] then
+        _writeDegraded(name)
         return
     end
-    _pendingTicks[fn] = true
-    _pendingSince[fn] = os.time()
+    if _pendingTicks[key] then
+        local age = os.time() - (_pendingSince[key] or 0)
+        if age < _stalePendingSeconds then return end
+        if _degradableWriters[name] then
+            _consecutiveStales[key] = (_consecutiveStales[key] or 0) + 1
+            _generation[key] = (_generation[key] or 0) + 1
+            if _consecutiveStales[key] >= _stalePendingRequired then
+                _enterDegraded(key, name)
+                return
+            end
+        end
+        -- One stale observation can be a healthy but overloaded game thread.
+        -- Drop this pending marker and give ExecuteInGameThread one more chance.
+        _pendingTicks[key] = nil
+        _pendingSince[key] = nil
+        return
+    end
+    _pendingTicks[key] = true
+    _pendingSince[key] = os.time()
+    local capturedGen = _generation[key] or 0
     -- ExecuteInGameThread can throw if neither EngineTick nor ProcessEvent
     -- hooks are available, and the global itself can transiently be nil during
     -- UE4SS init/shutdown. Resolve the global INSIDE the pcall boundary so a
@@ -567,14 +616,16 @@ local function dispatchTick(fn)
     -- UE4SS callback dispatcher as STATUS_FATAL_USER_CALLBACK_EXCEPTION.
     local ok, err = pcall(function()
         ExecuteInGameThread(function()
-            _pendingTicks[fn] = nil
-            _pendingSince[fn] = nil
+            if (_generation[key] or 0) ~= capturedGen then return end
+            _pendingTicks[key] = nil
+            _pendingSince[key] = nil
+            _consecutiveStales[key] = 0
             pcall(fn)
         end)
     end)
     if not ok then
-        _pendingTicks[fn] = nil
-        _pendingSince[fn] = nil
+        _pendingTicks[key] = nil
+        _pendingSince[key] = nil
         -- Mark the dispatcher dead so subsequent dispatches use the direct
         -- path immediately instead of re-throwing every tick. The next
         -- LoopAsync cycle runs the writer through the
@@ -607,18 +658,18 @@ Log.info("Core", string.format("Writers: query=%s livemap=%s poiscan=%s",
     tostring(_queryEnabled), tostring(_liveMapEnabled), tostring(_poiScanEnabled)))
 
 if Rcon and Config.isRconEnabled() then
-    if Query   and _queryEnabled   then Rcon.registerTickCallback(function() dispatchTick(_writer("Query"))   end) end
-    if LiveMap and _liveMapEnabled then Rcon.registerTickCallback(function() dispatchTick(_writer("LiveMap")) end) end
-    if POIScan and _poiScanEnabled then Rcon.registerTickCallback(function() dispatchTick(_writer("POIScan")) end) end
-    Rcon.registerTickCallback(function() dispatchTick(runModTicks) end)
+    if Query   and _queryEnabled   then Rcon.registerTickCallback(function() dispatchTick(_writer("Query"), "Query")   end) end
+    if LiveMap and _liveMapEnabled then Rcon.registerTickCallback(function() dispatchTick(_writer("LiveMap"), "LiveMap") end) end
+    if POIScan and _poiScanEnabled then Rcon.registerTickCallback(function() dispatchTick(_writer("POIScan"), "POIScan") end) end
+    Rcon.registerTickCallback(function() dispatchTick(runModTicks, "RunModTicks") end)
 else
     -- RCON disabled — standalone heartbeat
     if (Query or LiveMap or POIScan) and LoopAsync then
         LoopAsync(5000, function()
-            if Query   and _queryEnabled   then dispatchTick(_writer("Query"))   end
-            if LiveMap and _liveMapEnabled then dispatchTick(_writer("LiveMap")) end
-            if POIScan and _poiScanEnabled then dispatchTick(_writer("POIScan")) end
-            dispatchTick(runModTicks)
+            if Query   and _queryEnabled   then dispatchTick(_writer("Query"), "Query")   end
+            if LiveMap and _liveMapEnabled then dispatchTick(_writer("LiveMap"), "LiveMap") end
+            if POIScan and _poiScanEnabled then dispatchTick(_writer("POIScan"), "POIScan") end
+            dispatchTick(runModTicks, "RunModTicks")
             return false
         end)
     end

--- a/WindrosePlus/Scripts/modules/livemap.lua
+++ b/WindrosePlus/Scripts/modules/livemap.lua
@@ -17,6 +17,17 @@ LiveMap._cachedNodes = {}
 LiveMap._lastEntityCollect = 0
 LiveMap._entityCacheTTL = 120  -- clear stale entity cache after 2x entity interval
 LiveMap._wroteEmpty = false
+LiveMap._lastSnapshot = nil
+LiveMap._lastSnapshotTs = 0
+
+local function cloneTable(t)
+    if type(t) ~= "table" then return t end
+    local out = {}
+    for k, v in pairs(t) do
+        out[k] = cloneTable(v)
+    end
+    return out
+end
 
 function LiveMap.init(gameDir, config)
     local dataDir = gameDir .. "windrose_plus_data"
@@ -159,7 +170,7 @@ function LiveMap._collectAndWrite(collectEntities, prefetchedPlayers)
         LiveMap._lastEntityCollect = os.time()
     end
 
-    local data = json.encode({
+    local payload = {
         players = players,
         mobs = mobs,
         nodes = nodes,
@@ -167,13 +178,58 @@ function LiveMap._collectAndWrite(collectEntities, prefetchedPlayers)
         mob_count = #mobs,
         node_count = #nodes,
         timestamp = os.time()
-    })
+    }
+    LiveMap._lastSnapshot = cloneTable(payload)
+    LiveMap._lastSnapshotTs = payload.timestamp
+    LiveMap._writePayload(payload)
+end
+
+function LiveMap._writePayload(payload)
+    local data = json.encode(payload)
     local file = io.open(LiveMap._tmpPath, "w")
     if not file then return end
     file:write(data)
     file:close()
     os.remove(LiveMap._path)
     os.rename(LiveMap._tmpPath, LiveMap._path)
+end
+
+function LiveMap.writeDegraded(reason)
+    local now = os.time()
+    if now - LiveMap._lastPlayerWrite < LiveMap._playerInterval then return end
+    LiveMap._lastPlayerWrite = now
+    local payload
+    if LiveMap._lastSnapshot then
+        payload = cloneTable(LiveMap._lastSnapshot)
+        payload.timestamp = now
+        payload.degraded = true
+        payload.degraded_reason = reason or "execute_in_game_thread_starved"
+        payload.cache_age_sec = now - (LiveMap._lastSnapshotTs or now)
+    else
+        payload = {
+            players = {},
+            mobs = {},
+            nodes = {},
+            player_count = 0,
+            mob_count = 0,
+            node_count = 0,
+            timestamp = now,
+            degraded = true,
+            degraded_reason = reason or "execute_in_game_thread_starved"
+        }
+    end
+    if WindrosePlus and WindrosePlus.setMode then
+        pcall(WindrosePlus.setMode, "degraded")
+    end
+    LiveMap._writePayload(payload)
+end
+
+-- Force an immediate write (used by future dashboard/API refresh flows)
+function LiveMap.forceWrite()
+    LiveMap._lastPlayerWrite = os.time()
+    LiveMap._lastEntityWrite = os.time()
+    LiveMap._wroteEmpty = false
+    LiveMap._collectAndWrite(true, nil)
 end
 
 return LiveMap

--- a/WindrosePlus/Scripts/modules/query.lua
+++ b/WindrosePlus/Scripts/modules/query.lua
@@ -13,6 +13,17 @@ Query._interval = 5
 Query._idleInterval = 30
 Query._lastWrite = 0
 Query._serverInfo = nil
+Query._lastStatus = nil
+Query._lastStatusTs = 0
+
+local function cloneTable(t)
+    if type(t) ~= "table" then return t end
+    local out = {}
+    for k, v in pairs(t) do
+        out[k] = cloneTable(v)
+    end
+    return out
+end
 
 function Query.init(gameDir, config)
     local dataDir = gameDir .. "windrose_plus_data"
@@ -61,6 +72,84 @@ end
 function Query.forceWrite()
     Query._lastWrite = os.time()
     Query._collectAndWrite()
+end
+
+function Query._multipliers()
+    local cfg = Query._config or {}
+    return {
+        xp = cfg.getXpMultiplier and cfg.getXpMultiplier() or 1,
+        loot = cfg.getLootMultiplier and cfg.getLootMultiplier() or 1,
+        stack_size = cfg.getStackSizeMultiplier and cfg.getStackSizeMultiplier() or 1,
+        craft_efficiency = cfg.getCraftEfficiencyMultiplier and cfg.getCraftEfficiencyMultiplier() or 1,
+        craft_cost = cfg.getCraftEfficiencyMultiplier and cfg.getCraftEfficiencyMultiplier() or 1, -- DEPRECATED, removed in v1.2 (kept for old dashboards)
+        crop_speed = cfg.getCropSpeedMultiplier and cfg.getCropSpeedMultiplier() or 1,
+        weight = cfg.getWeightMultiplier and cfg.getWeightMultiplier() or 1,
+        inventory_size = cfg.getInventorySizeMultiplier and cfg.getInventorySizeMultiplier() or 1,
+        cooking_speed = cfg.getCookingSpeedMultiplier and cfg.getCookingSpeedMultiplier() or 1,
+        harvest_yield = cfg.getHarvestYieldMultiplier and cfg.getHarvestYieldMultiplier() or 1
+    }
+end
+
+function Query._writeStatus(status)
+    local content = json.encode(status)
+    local file = io.open(Query._tmpPath, "w")
+    if not file then return end
+    file:write(content)
+    file:close()
+    os.remove(Query._statusPath)
+    os.rename(Query._tmpPath, Query._statusPath)
+end
+
+function Query._degradedEmpty(reason)
+    if Query._gameDir then
+        Query._loadServerDescription(Query._gameDir)
+    end
+    local si = Query._serverInfo or {}
+    local cachedCount = 0
+    if WindrosePlus and WindrosePlus.state then
+        cachedCount = tonumber(WindrosePlus.state.playerCount) or 0
+    end
+    return {
+        server = {
+            name = si.name or "",
+            game = "Windrose",
+            version = si.version or "unknown",
+            windrose_plus = WindrosePlus and WindrosePlus.VERSION or "1.0.0",
+            invite_code = si.invite_code or "",
+            password_protected = si.password_protected or false,
+            max_players = si.max_players or 10,
+            player_count = cachedCount,
+            game_port = Query._config and Query._config.getGamePort and Query._config.getGamePort() or nil
+        },
+        players = {},
+        perf = {},
+        multipliers = Query._multipliers(),
+        timestamp = os.time(),
+        mode = "degraded",
+        degraded = true,
+        degraded_reason = reason or "execute_in_game_thread_starved"
+    }
+end
+
+function Query.writeDegraded(reason)
+    local now = os.time()
+    if now - Query._lastWrite < Query._interval then return end
+    Query._lastWrite = now
+    local status
+    if Query._lastStatus then
+        status = cloneTable(Query._lastStatus)
+        status.timestamp = now
+        status.mode = "degraded"
+        status.degraded = true
+        status.degraded_reason = reason or "execute_in_game_thread_starved"
+        status.cache_age_sec = now - (Query._lastStatusTs or now)
+    else
+        status = Query._degradedEmpty(reason)
+    end
+    if WindrosePlus and WindrosePlus.setMode then
+        pcall(WindrosePlus.setMode, "degraded")
+    end
+    Query._writeStatus(status)
 end
 
 -- Delegate to shared helper in WindrosePlus global
@@ -186,27 +275,12 @@ function Query._collectAndWrite()
         },
         players = players,
         perf = perf,
-        multipliers = {
-            xp = Query._config.getXpMultiplier(),
-            loot = Query._config.getLootMultiplier(),
-            stack_size = Query._config.getStackSizeMultiplier(),
-            craft_efficiency = Query._config.getCraftEfficiencyMultiplier(),
-            craft_cost = Query._config.getCraftEfficiencyMultiplier(), -- DEPRECATED, removed in v1.2 (kept for old dashboards)
-            crop_speed = Query._config.getCropSpeedMultiplier(),
-            weight = Query._config.getWeightMultiplier(),
-            inventory_size = Query._config.getInventorySizeMultiplier(),
-            cooking_speed = Query._config.getCookingSpeedMultiplier(),
-            harvest_yield = Query._config.getHarvestYieldMultiplier()
-        },
+        multipliers = Query._multipliers(),
         timestamp = os.time()
     }
-    local content = json.encode(status)
-    local file = io.open(Query._tmpPath, "w")
-    if not file then return end
-    file:write(content)
-    file:close()
-    os.remove(Query._statusPath)
-    os.rename(Query._tmpPath, Query._statusPath)
+    Query._lastStatus = cloneTable(status)
+    Query._lastStatusTs = status.timestamp
+    Query._writeStatus(status)
 end
 
 return Query


### PR DESCRIPTION
Fixes #46
Fixes #47

## Summary

Some hosts accept `ExecuteInGameThread` closures but never drain them. On those hosts Windrose+ v1.1.6 boots cleanly, RCON keeps polling, and `tick.beat` continues, but the game-thread writer closures never run. That leaves `server_status.json` and `livemap_data.json` missing forever.

This PR changes the stale-queue fallback to avoid async-thread UObject reads:

- requires two consecutive stale observations before declaring a writer starved
- writes degraded, file-only Query and LiveMap snapshots instead of running the normal collectors off-thread
- marks degraded status with `mode="degraded"`, `degraded=true`, and `degraded_reason="execute_in_game_thread_starved"`
- serves last-known cached Query/LiveMap snapshots with `cache_age_sec` when available; otherwise writes empty degraded snapshots
- suppresses POIScan in degraded mode instead of walking actors off-thread
- keeps `runModTicks` on the original game-thread path and excludes third-party callbacks from degraded fallback
- adds generation tokens so late queued closures no-op after a stale retry or degraded flip
- adds `LiveMap.forceWrite()` from @brazerZa's #48 helper, without the RCON-command callsite that would still collect UObjects from the async thread

## Safety notes

The degraded fallback path only uses cached Lua state, config getters, server-description file reads, JSON encode, and atomic temp-file writes. It does not call `Query.getPlayers()`, `LiveMap.writeIfDue()`, `FindAllOf`, `IsValid`, pawn/player-state accessors, or POIScan actor scans.

The existing `_hasExecuteInGameThread=false` fallback is left unchanged because that is the older UE4SS compatibility path and not the `ok=true` / never-drained failure mode fixed here.

The dispatcher still stores coalescing state in Lua tables, but all access stays inside the mod's Lua VM callbacks. Generation tokens guard late game-thread closures after the async loop has dropped a stale pending dispatch or switched a writer into degraded mode.

## Verification

- `luac -p WindrosePlus/Scripts/main.lua WindrosePlus/Scripts/modules/query.lua WindrosePlus/Scripts/modules/livemap.lua`
- `find WindrosePlus/Scripts -name '*.lua' -print0 | xargs -0 luac -p`
- local Lua smoke test with `FindAllOf` undefined calling `Query.writeDegraded()` and `LiveMap.writeDegraded()`; confirmed both degraded JSON files are written and no UObject path is touched
- `git diff --check`

## Suggested affected-host verification

1. Replace `WindrosePlus/Scripts/main.lua`, `modules/query.lua`, and `modules/livemap.lua` from this branch on an affected v1.1.6 server.
2. Restart the server and wait 30 seconds.
3. Confirm `windrose_plus_data/server_status.json` exists and has `mode: "degraded"` plus `degraded_reason: "execute_in_game_thread_starved"`.
4. Confirm `windrose_plus_data/livemap_data.json` exists and has `degraded: true`.
5. Confirm the UE4SS log has one warning per affected writer, for example `ExecuteInGameThread queue starved (#46) — Query in degraded mode`.
6. Leave the server running through player activity and confirm there are no engine crashes from the fallback path.