### PR TITLE
Add delayed hook helper and storage research notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ Alchemy_Potion_Healing_Great_HealthRestoreRatio = 0.8
 ### Mod Support
 Drop a Lua script into the `Mods/` folder and it loads automatically. Add custom commands, scheduled tasks, and player join/leave hooks. Changes hot-reload without restarting the server.
 
-**For modders** — full API reference, manifest format, and examples are in [docs/scripting-guide.md](docs/scripting-guide.md). Admin command list: [docs/commands.md](docs/commands.md). Config keys: [docs/config-reference.md](docs/config-reference.md).
+**For modders** — full API reference, manifest format, and examples are in [docs/scripting-guide.md](docs/scripting-guide.md). Admin command list: [docs/commands.md](docs/commands.md). Config keys: [docs/config-reference.md](docs/config-reference.md). Server-side storage hook notes: [docs/storage-hook-research.md](docs/storage-hook-research.md).
 
 Ships with an example mod:
 

--- a/WindrosePlus/Scripts/main.lua
+++ b/WindrosePlus/Scripts/main.lua
@@ -343,6 +343,87 @@ WindrosePlus.API.registerTickCallback = function(fn, intervalMs)
     table.insert(_modTickCallbacks, { fn = fn, interval = (intervalMs or 5000) / 1000, lastRun = 0 })
 end
 
+-- Some Blueprint-backed UFunctions exist before their native function pointer is
+-- ready for UE4SS hooks. This helper retries registration for mods that want to
+-- hook late-discovered game surfaces without hand-rolling LoopAsync timers.
+WindrosePlus.API.registerHookWhenAvailable = function(path, preHook, postHook, options)
+    if type(postHook) == "table" and options == nil then
+        options = postHook
+        postHook = nil
+    end
+    if type(options) ~= "table" then options = {} end
+
+    local handle = {
+        path = path,
+        attempts = 0,
+        registered = false,
+        failed = false,
+        cancelled = false,
+        lastError = nil,
+        preHookId = nil,
+        postHookId = nil,
+    }
+
+    function handle.cancel()
+        handle.cancelled = true
+    end
+
+    local source = tostring(options.logSource or "API")
+    local intervalMs = tonumber(options.intervalMs) or 5000
+    local maxAttempts = tonumber(options.maxAttempts) or 24
+    if intervalMs < 250 then intervalMs = 250 end
+    if maxAttempts < 1 then maxAttempts = 1 end
+
+    local function fail(message)
+        handle.failed = true
+        handle.lastError = tostring(message)
+        Log.warn(source, "Hook unavailable: " .. tostring(path) .. " (" .. handle.lastError .. ")")
+        if type(options.onFailed) == "function" then pcall(options.onFailed, handle) end
+        return true
+    end
+
+    local function tryRegister()
+        if handle.cancelled or handle.registered or handle.failed then return true end
+        if type(path) ~= "string" or path == "" then return fail("invalid hook path") end
+        if type(preHook) ~= "function" and type(postHook) ~= "function" then return fail("missing hook callback") end
+
+        handle.attempts = handle.attempts + 1
+        if type(RegisterHook) ~= "function" then
+            handle.lastError = "RegisterHook not available"
+        else
+            local ok, id1, id2
+            if type(postHook) == "function" then
+                ok, id1, id2 = pcall(RegisterHook, path, preHook, postHook)
+            else
+                ok, id1, id2 = pcall(RegisterHook, path, preHook)
+            end
+            if ok then
+                handle.registered = true
+                handle.preHookId = id1
+                handle.postHookId = id2
+                Log.info(source, "Hook registered: " .. path .. " after " .. handle.attempts .. " attempt(s)")
+                if type(options.onRegistered) == "function" then pcall(options.onRegistered, handle) end
+                return true
+            end
+            handle.lastError = tostring(id1)
+        end
+
+        if handle.attempts >= maxAttempts then
+            return fail(handle.lastError or "max attempts reached")
+        end
+        return false
+    end
+
+    local done = tryRegister()
+    if not done and type(LoopAsync) == "function" then
+        LoopAsync(intervalMs, tryRegister)
+    elseif not done then
+        fail("LoopAsync not available")
+    end
+
+    return handle
+end
+
 -- Player join/leave event callbacks
 local _playerJoinCallbacks = {}
 local _playerLeaveCallbacks = {}

--- a/docs/scripting-guide.md
+++ b/docs/scripting-guide.md
@@ -91,6 +91,40 @@ end, 10000)  -- interval in milliseconds (default: 5000)
 
 Tick callbacks run on the main game thread during the 5-second polling loop. Keep them fast -- long-running work blocks the server.
 
+### Delayed UE4SS Hooks
+
+```lua
+API.registerHookWhenAvailable(path, preHook, postHook, options)
+```
+
+Register a UE4SS hook immediately if possible, or retry for Blueprint/game functions that exist before their function pointer is hookable. This is useful for reverse-engineering server-side game surfaces that may only become hookable after the world finishes loading.
+
+```lua
+local handle = API.registerHookWhenAvailable(
+    "/Script/R5.R5BuildingCenterStorageComponent:OnInventoryViewChanged",
+    function(context)
+        API.log("debug", "StorageProbe", "storage view changed")
+    end,
+    {
+        intervalMs = 5000,
+        maxAttempts = 24,
+        onRegistered = function(h)
+            API.log("info", "StorageProbe", "hooked after " .. h.attempts .. " attempt(s)")
+        end
+    }
+)
+```
+
+`postHook` is optional. You may pass the options table as the third argument when you only need one callback:
+
+```lua
+API.registerHookWhenAvailable("/Script/R5.SomeClass:SomeFunction", function(context)
+    -- keep hook work fast
+end, { maxAttempts = 12 })
+```
+
+The returned handle includes `path`, `attempts`, `registered`, `failed`, `cancelled`, `lastError`, `preHookId`, `postHookId`, and `cancel()`. Call `handle.cancel()` only when you want to stop future retries; already-registered hooks remain owned by UE4SS for the life of this Lua state.
+
 ### Data Access
 
 ```lua

--- a/docs/storage-hook-research.md
+++ b/docs/storage-hook-research.md
@@ -1,0 +1,96 @@
+# Storage Hook Research
+
+Status: research note. This is not a supported chest-locking feature yet.
+
+This document captures current dedicated-server hook findings for storage-related gameplay. The useful discovery is that WindrosePlus can observe real server-side storage components, but the observed callbacks do not yet expose a safe authorization point for opening, depositing, taking, or transferring items.
+
+## Current Findings
+
+Dedicated-server UE4SS can register many R5 hooks successfully, including `/Script/R5.*` functions and at least one Blueprint path under `/Game/...GC_InteractNotification...:OnExecute`.
+
+Some Blueprint/game functions are not hookable during initial mod load. In one storage test, `GC_InteractNotification:OnExecute` first failed with `UFunction::Func: 0x0`, then registered after a delayed rescan. For this reason, mods should prefer `WindrosePlus.API.registerHookWhenAvailable` when probing functions that may appear during or after world load.
+
+Client UI, HUD, HFSM, and inventory view-model classes appear quiet on dedicated servers. Hooks such as `R5HUD:LaunchHFSM`, `R5HUD:TriggerHFSM`, `R5SC_Default:GetViewModel`, and `R5BaseInventoryVM:*` registered but did not fire during storage testing. Server-side mods should not expect the client inventory UI path to execute on the dedicated server.
+
+The reliable server-side storage signals found so far are:
+
+```text
+/Script/R5.R5BuildingCenterStorageComponent:OnInventoryViewChanged
+/Script/R5.R5ProximityStorageComponent:OnStorageComponentChanged
+```
+
+`R5BuildingCenterStorageComponent:GetOuter()` resolves to the actual `BP_BuildingBlock_BuildingCenterT01_C` actor, including world location. That makes it useful for mapping storage centers to world/building actors.
+
+`R5ProximityStorageComponent` lives under `BP_R5PlayerState_C`, so proximity storage changes can be associated with a player-state object.
+
+Observed storage callbacks had `arg_count = 0` and did not expose item, quantity, player, or action payloads. They should be treated as observer/update notifications, not as "can this player access this storage?" or "can this item move?" authorization hooks.
+
+## Actionable Work
+
+Use delayed registration for probes that may not be hookable at initial mod load:
+
+```lua
+local API = WindrosePlus.API
+
+API.registerHookWhenAvailable(
+    "/Script/R5.R5BuildingCenterStorageComponent:OnInventoryViewChanged",
+    function(context)
+        API.log("debug", "StorageProbe", "building center inventory view changed")
+    end,
+    { intervalMs = 5000, maxAttempts = 24, logSource = "StorageProbe" }
+)
+```
+
+Use the existing debug/reflection commands to look for pre-access or pre-transfer functions around the live objects:
+
+```text
+wp.inspect R5BuildingCenterStorageComponent
+wp.inspect R5ProximityStorageComponent
+wp.fields R5BuildingCenterStorageComponent storage
+wp.fields R5ProximityStorageComponent storage
+wp.methods R5BuildingCenterStorageComponent access
+wp.methods R5BuildingCenterStorageComponent transfer
+wp.methods R5ProximityStorageComponent request
+wp.peek R5ProximityStorageComponent <field_from_wp_fields>
+```
+
+Useful filter families to try with `wp.fields` and `wp.methods`:
+
+```text
+Can
+Try
+Request
+Server
+Open
+Access
+Use
+Interact
+Add
+Remove
+Transfer
+Inventory
+Storage
+Owner
+Player
+Permission
+Lock
+```
+
+If a candidate hook fires before storage open or item transfer, the next proof should log:
+
+```text
+function path
+argument count
+argument class/full name values
+Context/GetOuter() chain
+player-state or controller association
+whether returning/overriding can deny the action
+```
+
+## Non-Goals Until a Gate Is Found
+
+Do not ship chest locking based only on `OnInventoryViewChanged` or `OnStorageComponentChanged`. Those callbacks are useful telemetry, but they appear to fire after state/view changes and do not carry enough payload to enforce access safely.
+
+Do not depend on HUD, HFSM, or client inventory view-model hooks for dedicated-server authority. Those paths may be client-only even when UE4SS can register the hook.
+
+Do not mutate inventory data from observer callbacks unless the item API and save-state behavior are understood. WindrosePlus already has several inventory and stack-size safety lessons in related issues, and storage enforcement should stay conservative until an actual server authorization hook is identified.


### PR DESCRIPTION
## Summary
- Add WindrosePlus.API.registerHookWhenAvailable for bounded delayed UE4SS hook registration.
- Document the helper in the scripting guide with a storage-component example.
- Add storage-hook research notes that capture current dedicated-server findings and mark chest locking as blocked until a real pre-access/pre-transfer authorization hook is found.

## Why
Some Blueprint/game functions are not hookable at initial mod load but become hookable after world load. The storage research found reliable observer hooks, but not a safe permission gate yet. This gives mod authors a reusable helper for late-discovered hooks while documenting the current storage/chest-locking limits.

## Validation
- git diff --cached --check
- Not runtime-tested in UE4SS/WindrosePlus from this checkout; local lua/luac/luacheck are not installed.