### PR TITLE
Add pull request CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,70 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  powershell-syntax:
+    name: PowerShell syntax
+    runs-on: windows-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Parse PowerShell scripts
+        shell: pwsh
+        run: |
+          $files = Get-ChildItem -Path . -Recurse -File -Filter '*.ps1' |
+            Where-Object { $_.FullName -notmatch '\\.git\\' } |
+            Sort-Object FullName
+
+          $failed = $false
+          foreach ($file in $files) {
+            $tokens = $null
+            $errors = $null
+            [System.Management.Automation.Language.Parser]::ParseFile($file.FullName, [ref]$tokens, [ref]$errors) | Out-Null
+
+            if ($errors.Count -gt 0) {
+              $failed = $true
+              Write-Error "PowerShell parse errors in $($file.FullName)"
+              foreach ($err in $errors) {
+                Write-Error ("  line {0}, column {1}: {2}" -f $err.Extent.StartLineNumber, $err.Extent.StartColumnNumber, $err.Message)
+              }
+            }
+          }
+
+          if ($failed) {
+            throw "PowerShell syntax validation failed"
+          }
+
+          Write-Host "Parsed $($files.Count) PowerShell script(s)."
+
+  windrose-heal-tests:
+    name: windrose-heal tests
+    runs-on: windows-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache cargo registry and target
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: tools/windrose-heal -> target
+
+      - name: Test windrose-heal
+        run: cargo test --locked --manifest-path tools/windrose-heal/Cargo.toml


### PR DESCRIPTION
## Summary
- Add a CI workflow for pull requests and pushes to main.
- Parse every repository PowerShell script with the built-in PowerShell parser on Windows.
- Run windrose-heal Rust tests with cargo test --locked, matching the release workflow's test coverage but moving it earlier in review.

## Why
The repo currently validates windrose-heal during tagged releases, but routine PRs do not get basic validation before maintainer review. This gives future changes a small safety net for PowerShell syntax and the Rust repair tool without touching gameplay behavior.

## Validation
- git diff --cached --check
- Local PowerShell parser pass over 9 .ps1 files
- cargo is not installed in this local checkout, so the Rust test step is left to GitHub Actions where the workflow installs Rust.