### PR TITLE
Add per-resource harvest yield via windrose_plus.harvest.ini

### DIFF
--- a/config/windrose_plus.harvest.default.ini
+++ b/config/windrose_plus.harvest.default.ini
@@ -1,0 +1,59 @@
+; ============================================================
+; WindrosePlus Per-Resource Harvest Yield
+; ============================================================
+;
+; Per-resource multipliers for harvested resources. Stacks on top of
+; multipliers.harvest_yield from windrose_plus.json:
+;
+;     final_yield = harvest_yield * <per-resource value>
+;
+; Default 1.0 means "use harvest_yield only — no per-resource override."
+; Set wood=5.0 + harvest_yield=1.0 → wood drops 5x, everything else stays.
+; Set wood=5.0 + harvest_yield=2.0 → wood drops 10x, everything else 2x.
+;
+; Affects:
+;   - LootTables/Foliage/*.json   — per-entry LootData[].Min/Max scaled
+;     by the multiplier matching that entry's resource family
+;   - ContextualSpawners destroy scores — segmented-tree destroys use
+;     [Resources] Wood; copper-cave digs use CopperOre; iron-cavern
+;     digs use Iron
+;
+; Resource family is detected by matching `Resource_<Name>_T<digit>` in
+; the LootItem path (e.g. /R5BusinessRules/.../DA_DID_Resource_Wood_T01
+; → "Wood"). Match is case-insensitive (Wood, wood, WOOD all work).
+; Unknown families fall through to harvest_yield only.
+;
+; Like the other type-specific INIs, save this file as
+; windrose_plus.harvest.ini (drop the .default) in your server root to
+; activate. Edits trigger a PAK rebuild on the next launch.
+; ============================================================
+
+[Resources]
+; Wood — primary drop from trees (segmented and small)
+Wood        = 1.0
+; Bark — higher-tier tree drop
+Bark        = 1.0
+; Plant fiber — grasses, agave, hemp, flax bushes
+FiberPlant  = 1.0
+; Stone outcrops
+Stone       = 1.0
+; Clay deposits
+Clay        = 1.0
+; Ash deposits
+Ash         = 1.0
+; Sulfur outcrops
+Sulfur      = 1.0
+; Copper ore — surface nodes + copper cave dig volumes
+CopperOre   = 1.0
+; Iron ore — iron cavern dig volumes
+Iron        = 1.0
+; Charcoal from coal nodes
+Charcoal    = 1.0
+; Animal-derived (feather, fat, leather, horns, tusks, bezoar)
+; — uncommon in foliage tables, more usually creature drops which
+;   are not affected by this file.
+Feather     = 1.0
+Fat         = 1.0
+Leather     = 1.0
+GoatHorn    = 1.0
+Bezoar      = 1.0

--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -10,6 +10,7 @@ Windrose+ uses `windrose_plus.json` for everyday settings and optional `.ini` fi
 | `windrose_plus.food.ini` | Food buffs, consumables, alchemy items |
 | `windrose_plus.gear.ini` | Armor sets, set bonuses, jewelry |
 | `windrose_plus.entities.ini` | Land and naval entity base stats |
+| `windrose_plus.harvest.ini` | Per-resource harvest yield overrides (wood, stone, ore, etc.) |
 
 ---
 
@@ -65,6 +66,63 @@ Example:
 
 ---
 
+## windrose_plus.harvest.ini (Per-Resource Yield)
+
+Optional file. Adds per-resource multipliers for harvest yield, stacking
+multiplicatively on top of `multipliers.harvest_yield` from `windrose_plus.json`:
+
+```text
+final_yield = harvest_yield * <per-resource value>
+```
+
+Default `1.0` for every key means "use `harvest_yield` only, no override".
+Drop a value to scale only that resource family. Wood-only example
+(everything else stays at vanilla, wood drops 5x):
+
+```ini
+[Resources]
+Wood = 5.0
+```
+
+Combined example (`harvest_yield = 2.0` in `windrose_plus.json` + this file):
+
+```ini
+[Resources]
+Wood        = 3.0   ; wood drops 2.0 * 3.0 = 6x
+Stone       = 1.0   ; stone drops 2.0 * 1.0 = 2x (just harvest_yield)
+CopperOre   = 0.5   ; copper drops 2.0 * 0.5 = 1x (back to vanilla)
+```
+
+### [Resources]
+
+Keys are UE asset family names. The matcher reads the
+`Resource_<Name>_T<digit>` token from each loot entry's path
+(e.g. `DA_DID_Resource_Wood_T01` -> `Wood`). Case-insensitive — `Wood`,
+`wood`, and `WOOD` all match.
+
+| Key | Default | Where it applies |
+|-----|---------|------------------|
+| `Wood` | `1.0` | Tree drops + `SegmentTreesAndMineralDestroy` contextual scores |
+| `Bark` | `1.0` | Higher-tier tree drops |
+| `FiberPlant` | `1.0` | Grasses, agave, hemp, flax bushes |
+| `Stone` | `1.0` | Stone outcrops |
+| `Clay` | `1.0` | Clay deposits |
+| `Ash` | `1.0` | Ash deposits |
+| `Sulfur` | `1.0` | Sulfur outcrops |
+| `CopperOre` | `1.0` | Surface copper nodes + `CopperCaves_DigVolumesDestroy` |
+| `Iron` | `1.0` | `IronCaverns_DigVolumesDestroy` |
+| `Charcoal` | `1.0` | Coal nodes |
+| `Feather`, `Fat`, `Leather`, `GoatHorn`, `Bezoar` | `1.0` | Animal-derived. Mostly creature drops (not affected); foliage tables that include them are scaled here. |
+
+Unknown family names in the INI are silently ignored. Unknown families on
+in-game loot entries fall through to `harvest_yield` only.
+
+Edits to this file trigger a PAK rebuild on the next launch via
+`StartWindrosePlusServer.bat`, the same way the other type-specific INIs
+do.
+
+---
+
 ## windrose_plus.ini (Main Config)
 
 ### [Server]
@@ -94,7 +152,7 @@ Global server multipliers. `1.0` = default, `2.0` = double, `0.5` = half.
 | `craft_efficiency` | `1` | Crafting efficiency. Higher = cheaper recipes (`2.0` = half cost, `0.5` = double cost). The legacy key `craft_cost` is still accepted with identical semantics for backward compatibility. |
 | `crop_speed` | `1` | Disabled/no-op. Kept only so old configs still parse; changing it does not change crop timing. |
 | `cooking_speed` | `1` | Cooking / fermentation / smelting speed (2.0 = twice as fast) |
-| `harvest_yield` | `1` | Resource node yield (berries, ore, wood, herbs, etc.). Scales `Amount.Min`/`Max` per node; minimum stays at `1` after rounding. |
+| `harvest_yield` | `1` | Resource node yield (berries, ore, wood, herbs, etc.). Scales `Amount.Min`/`Max` per node; minimum stays at `1` after rounding. For per-resource overrides (e.g. wood-only), see the [windrose_plus.harvest.ini](#windrose_plusharvestini-per-resource-yield) section below. |
 | `weight` | `1` | Disabled/no-op. Kept only so old configs still parse; changing it does not change item weight. |
 | `inventory_size` | `1` | Disabled/no-op. Kept only so old configs still parse; changing it does not change slot counts. |
 | `points_per_level` | `1` | Disabled/no-op. Kept only so old configs still parse; changing it does not grant points. |

--- a/server/windrose_plus_server.ps1
+++ b/server/windrose_plus_server.ps1
@@ -823,7 +823,8 @@ try {
                         (Join-Path $gameDir "windrose_plus.weapons.ini"),
                         (Join-Path $gameDir "windrose_plus.food.ini"),
                         (Join-Path $gameDir "windrose_plus.gear.ini"),
-                        (Join-Path $gameDir "windrose_plus.entities.ini")
+                        (Join-Path $gameDir "windrose_plus.entities.ini"),
+                        (Join-Path $gameDir "windrose_plus.harvest.ini")
                     )
                     $ctConfigPresent = $false
                     foreach ($p in $iniPaths) {
@@ -866,6 +867,33 @@ try {
                                     }
                                 }
                             } catch { }
+                        }
+                        # windrose_plus.harvest.ini alone (no non-default
+                        # multipliers in the JSON) also requires a Multipliers
+                        # PAK. Inline parse — same `Key = Number` shape that
+                        # Read-HarvestIni handles in MultiplierPakBuilder.ps1.
+                        if (-not $expectMultPak) {
+                            $harvestIniPath = Join-Path $gameDir "windrose_plus.harvest.ini"
+                            if (Test-Path -LiteralPath $harvestIniPath) {
+                                try {
+                                    foreach ($raw in Get-Content -LiteralPath $harvestIniPath) {
+                                        $line = $raw.Trim()
+                                        if (-not $line) { continue }
+                                        $first = $line[0]
+                                        if ($first -eq ';' -or $first -eq '#' -or $first -eq '[') { continue }
+                                        $eq = $line.IndexOf('=')
+                                        if ($eq -lt 1) { continue }
+                                        $val = $line.Substring($eq + 1)
+                                        $semi = $val.IndexOf(';')
+                                        if ($semi -ge 0) { $val = $val.Substring(0, $semi) }
+                                        $val = $val.Trim()
+                                        $d = 0.0
+                                        if ([double]::TryParse($val, [System.Globalization.NumberStyles]::Float, [System.Globalization.CultureInfo]::InvariantCulture, [ref]$d)) {
+                                            if ($d -ne 1.0) { $expectMultPak = $true; break }
+                                        }
+                                    }
+                                } catch { }
+                            }
                         }
 
                         if (-not $script:IniParserLoaded) {

--- a/tools/WindrosePlus-BuildPak.ps1
+++ b/tools/WindrosePlus-BuildPak.ps1
@@ -97,7 +97,8 @@ $iniConfigPaths = @(
     (Join-Path $iniDir "windrose_plus.weapons.ini"),
     (Join-Path $iniDir "windrose_plus.food.ini"),
     (Join-Path $iniDir "windrose_plus.gear.ini"),
-    (Join-Path $iniDir "windrose_plus.entities.ini")
+    (Join-Path $iniDir "windrose_plus.entities.ini"),
+    (Join-Path $iniDir "windrose_plus.harvest.ini")
 )
 if (-not $DefaultPath) {
     $DefaultPath = Join-Path $ServerDir "windrose_plus\config\windrose_plus.default.ini"
@@ -304,6 +305,16 @@ $hasMultipliers = $false
 foreach ($prop in $multipliers.GetEnumerator()) {
     if ($prop.Key -eq "points_per_level") { continue }
     if ($prop.Value -ne 1.0) { $hasMultipliers = $true; break }
+}
+# windrose_plus.harvest.ini alone (no non-default value in windrose_plus.json)
+# also requires a Multipliers PAK. Read-HarvestIni is dot-sourced from
+# MultiplierPakBuilder.ps1.
+if (-not $hasMultipliers) {
+    $harvestIniPath = Join-Path $iniDir "windrose_plus.harvest.ini"
+    $perResourceHarvest = Read-HarvestIni -Path $harvestIniPath
+    foreach ($v in $perResourceHarvest.Values) {
+        if ($v -ne 1.0) { $hasMultipliers = $true; break }
+    }
 }
 $hasCT = ($ctConfig.Count -gt 0)
 

--- a/tools/lib/MultiplierPakBuilder.ps1
+++ b/tools/lib/MultiplierPakBuilder.ps1
@@ -166,6 +166,46 @@ function Test-WindrosePlusPakConflicts {
     return @($conflicts)
 }
 
+# Parse windrose_plus.harvest.ini into a {ResourceName -> multiplier}
+# hashtable. Section headers are ignored; only `Key = Number` lines are
+# read. Inline `;` comments are stripped. Values clamped to >= 0.01.
+# Missing file or no readable values -> empty hashtable.
+function Read-HarvestIni {
+    param([string]$Path)
+    $out = @{}
+    if (-not $Path -or -not (Test-Path -LiteralPath $Path)) { return $out }
+    foreach ($raw in Get-Content -LiteralPath $Path) {
+        $line = $raw.Trim()
+        if (-not $line) { continue }
+        $first = $line[0]
+        if ($first -eq ';' -or $first -eq '#' -or $first -eq '[') { continue }
+        $eq = $line.IndexOf('=')
+        if ($eq -lt 1) { continue }
+        $key = $line.Substring(0, $eq).Trim()
+        $val = $line.Substring($eq + 1)
+        $semi = $val.IndexOf(';')
+        if ($semi -ge 0) { $val = $val.Substring(0, $semi) }
+        $val = $val.Trim()
+        $d = 0.0
+        if ([double]::TryParse($val, [System.Globalization.NumberStyles]::Float, [System.Globalization.CultureInfo]::InvariantCulture, [ref]$d)) {
+            $out[$key] = [Math]::Max(0.01, $d)
+        }
+    }
+    return $out
+}
+
+# Pull the resource family from a UE LootItem soft-object path.
+# `/R5BusinessRules/.../DA_DID_Resource_Wood_T01.DA_DID_Resource_Wood_T01`
+# -> "Wood". Returns $null when nothing matches.
+function Get-ResourceFamily {
+    param([string]$LootItemPath)
+    if (-not $LootItemPath) { return $null }
+    if ($LootItemPath -match 'Resource_([A-Za-z][A-Za-z0-9]*)_T\d') {
+        return $Matches[1]
+    }
+    return $null
+}
+
 function Build-MultiplierPak {
     <#
     .SYNOPSIS
@@ -255,7 +295,14 @@ function Build-MultiplierPak {
     $cookSpeed = [Math]::Max(0.01, $cookSpeed)
     $harvestYield = [Math]::Max(0.01, $harvestYield)
 
-    $allDefault = ($loot -eq 1.0 -and $xp -eq 1.0 -and $stackSize -eq 1.0 -and $craftEfficiency -eq 1.0 -and $cropSpeed -eq 1.0 -and $weight -eq 1.0 -and $invSize -eq 1.0 -and $pointsPerLvl -eq 1.0 -and $cookSpeed -eq 1.0 -and $harvestYield -eq 1.0)
+    # Per-resource harvest overrides from windrose_plus.harvest.ini
+    # (optional). Stacks multiplicatively on $harvestYield.
+    $harvestIniPath = if ($ServerDir) { Join-Path $ServerDir "windrose_plus.harvest.ini" } else { $null }
+    $perResource = Read-HarvestIni -Path $harvestIniPath
+    $perResourceActive = $false
+    foreach ($v in $perResource.Values) { if ($v -ne 1.0) { $perResourceActive = $true; break } }
+
+    $allDefault = ($loot -eq 1.0 -and $xp -eq 1.0 -and $stackSize -eq 1.0 -and $craftEfficiency -eq 1.0 -and $cropSpeed -eq 1.0 -and $weight -eq 1.0 -and $invSize -eq 1.0 -and $pointsPerLvl -eq 1.0 -and $cookSpeed -eq 1.0 -and $harvestYield -eq 1.0 -and -not $perResourceActive)
     if ($allDefault) {
         $result.Error = "All multipliers are 1.0 (default). Nothing to build."
         return $result
@@ -479,8 +526,24 @@ function Build-MultiplierPak {
         # plus LootData[].Min/Max in mineral foliage loot tables (copper/iron/etc.
         # nodes are loot-table-driven, not ResourceSpawner-driven). Does not touch
         # RespawnInterval — yield per node, not respawn rate.
-        if ($harvestYield -ne 1.0) {
-            Write-Host "  Modifying harvest yields (${harvestYield}x)..."
+        # Per-resource overrides from windrose_plus.harvest.ini stack multiplicatively.
+        if ($harvestYield -ne 1.0 -or $perResourceActive) {
+            if ($perResourceActive) {
+                $perResStr = ($perResource.GetEnumerator() | Where-Object { $_.Value -ne 1.0 } | ForEach-Object { "$($_.Key)=$($_.Value)x" }) -join ", "
+                Write-Host "  Modifying harvest yields (base=${harvestYield}x; per-resource: $perResStr)..."
+            } else {
+                Write-Host "  Modifying harvest yields (${harvestYield}x)..."
+            }
+
+            # Per-family applied counter — increments each time a non-default
+            # per-resource multiplier is matched against an asset family.
+            # Surfaces typos: a configured `Wod=5.0` produces no matches and
+            # ends up reported as `Wod=0` in the summary line below.
+            $perFamilyApplied = @{}
+            foreach ($k in $perResource.Keys) {
+                if ($perResource[$k] -ne 1.0) { $perFamilyApplied[$k] = 0 }
+            }
+
             $harvFiles = Invoke-RepakList -Repak $repak -AesKey $AesKey -PakPath $pak -Filter "ResourcesSpawners/"
             $harvMod = 0
             foreach ($hf in $harvFiles) {
@@ -493,8 +556,16 @@ function Build-MultiplierPak {
                     if (-not $variant.Collection) { continue }
                     foreach ($entry in $variant.Collection) {
                         if ($null -ne $entry.Amount -and $null -ne $entry.Amount.Min -and $null -ne $entry.Amount.Max) {
-                            $entry.Amount.Min = [Math]::Max(1, [int]($entry.Amount.Min * $harvestYield))
-                            $entry.Amount.Max = [Math]::Max(1, [int]($entry.Amount.Max * $harvestYield))
+                            $resMult = 1.0
+                            $family = Get-ResourceFamily -LootItemPath $entry.ResourceParams
+                            if ($family -and $perResource.ContainsKey($family)) {
+                                $resMult = $perResource[$family]
+                                if ($perFamilyApplied.ContainsKey($family)) { $perFamilyApplied[$family]++ }
+                            }
+                            $eff = $harvestYield * $resMult
+                            if ($eff -eq 1.0) { continue }
+                            $entry.Amount.Min = [Math]::Max(1, [int]($entry.Amount.Min * $eff))
+                            $entry.Amount.Max = [Math]::Max(1, [int]($entry.Amount.Max * $eff))
                             $changed = $true
                         }
                     }
@@ -533,8 +604,16 @@ function Build-MultiplierPak {
                 foreach ($item in $data.LootData) {
                     if ($item.LootItem -and $item.LootItem -like "*/InventoryItems/Equipments/*") { continue }
                     if ($null -ne $item.Min -and $null -ne $item.Max) {
-                        $item.Min = [Math]::Max(1, [int]($item.Min * $harvestYield))
-                        $item.Max = [Math]::Max(1, [int]($item.Max * $harvestYield))
+                        $resMult = 1.0
+                        $family = Get-ResourceFamily -LootItemPath $item.LootItem
+                        if ($family -and $perResource.ContainsKey($family)) {
+                            $resMult = $perResource[$family]
+                            if ($perFamilyApplied.ContainsKey($family)) { $perFamilyApplied[$family]++ }
+                        }
+                        $eff = $harvestYield * $resMult
+                        if ($eff -eq 1.0) { continue }
+                        $item.Min = [Math]::Max(1, [int]($item.Min * $eff))
+                        $item.Max = [Math]::Max(1, [int]($item.Max * $eff))
                         $changed = $true
                     }
                 }
@@ -550,8 +629,9 @@ function Build-MultiplierPak {
             # Pickup-resource loot tables (LootTables/PickupResource/*.json):
             # sulfur pickup chests, salt rocks, mushrooms, shells, dodo eggs,
             # etc. Same LootData[].Min/Max schema as foliage. The loot pass
-            # already scaled these by loot multiplier; stack harvest_yield on
-            # top by reading the working file from tmpDir if present.
+            # already scaled these by loot multiplier; stack harvest_yield
+            # (and any per-resource override) on top by reading the working
+            # file from tmpDir if present.
             $pickupFiles = Invoke-RepakList -Repak $repak -AesKey $AesKey -PakPath $pak -Filter "LootTables/PickupResource/"
             $pickupMod = 0
             foreach ($pf in $pickupFiles) {
@@ -570,8 +650,16 @@ function Build-MultiplierPak {
                 foreach ($item in $data.LootData) {
                     if ($item.LootItem -and $item.LootItem -like "*/InventoryItems/Equipments/*") { continue }
                     if ($null -ne $item.Min -and $null -ne $item.Max) {
-                        $item.Min = [Math]::Max(1, [int]($item.Min * $harvestYield))
-                        $item.Max = [Math]::Max(1, [int]($item.Max * $harvestYield))
+                        $resMult = 1.0
+                        $family = Get-ResourceFamily -LootItemPath $item.LootItem
+                        if ($family -and $perResource.ContainsKey($family)) {
+                            $resMult = $perResource[$family]
+                            if ($perFamilyApplied.ContainsKey($family)) { $perFamilyApplied[$family]++ }
+                        }
+                        $eff = $harvestYield * $resMult
+                        if ($eff -eq 1.0) { continue }
+                        $item.Min = [Math]::Max(1, [int]($item.Min * $eff))
+                        $item.Max = [Math]::Max(1, [int]($item.Max * $eff))
                         $changed = $true
                     }
                 }
@@ -585,14 +673,24 @@ function Build-MultiplierPak {
             if ($pickupMod -gt 0) { Write-Host "    Modified $pickupMod pickup resource loot tables" }
 
             # Segmented trees and cave dig volumes use contextual destroy
-            # scores instead of the LootData tables above.
+            # scores instead of the LootData tables above. Each file maps
+            # to a single resource family for the per-resource multiplier;
+            # `null` family means "use harvest_yield only".
             $contextualHarvestFiles = @(
-                "R5/Content/Gameplay/ContextualSpawners/DA_ContextualSpawnerParams_Player_SegmentTreesAndMineralDestroy.json",
-                "R5/Content/Gameplay/ContextualSpawners/DA_ContextualSpawnerParams_Player_CopperCaves_DigVolumesDestroy.json",
-                "R5/Content/Gameplay/ContextualSpawners/DA_ContextualSpawnerParams_Player_IronCaverns_DigVolumesDestroy.json"
+                @{ Path = "R5/Content/Gameplay/ContextualSpawners/DA_ContextualSpawnerParams_Player_SegmentTreesAndMineralDestroy.json"; Family = "Wood" },
+                @{ Path = "R5/Content/Gameplay/ContextualSpawners/DA_ContextualSpawnerParams_Player_CopperCaves_DigVolumesDestroy.json"; Family = "CopperOre" },
+                @{ Path = "R5/Content/Gameplay/ContextualSpawners/DA_ContextualSpawnerParams_Player_IronCaverns_DigVolumesDestroy.json"; Family = "Iron" }
             )
             $contextualMod = 0
-            foreach ($cf in $contextualHarvestFiles) {
+            foreach ($cfEntry in $contextualHarvestFiles) {
+                $cf = $cfEntry.Path
+                $cfResMult = 1.0
+                if ($cfEntry.Family -and $perResource.ContainsKey($cfEntry.Family)) {
+                    $cfResMult = $perResource[$cfEntry.Family]
+                    if ($perFamilyApplied.ContainsKey($cfEntry.Family)) { $perFamilyApplied[$cfEntry.Family]++ }
+                }
+                $cfEff = $harvestYield * $cfResMult
+                if ($cfEff -eq 1.0) { continue }
                 $outPath = Join-Path $tmpDir $cf
                 $existedBefore = Test-Path -LiteralPath $outPath
                 if ($existedBefore) {
@@ -605,13 +703,13 @@ function Build-MultiplierPak {
                 if (-not $data.EventHandlers) { continue }
                 $changed = $false
                 if ($null -ne $data.MaxScore) {
-                    $data.MaxScore = [Math]::Max(0.0, [Math]::Round(([double]$data.MaxScore) * $harvestYield, 4))
+                    $data.MaxScore = [Math]::Max(0.0, [Math]::Round(([double]$data.MaxScore) * $cfEff, 4))
                     $changed = $true
                 }
                 foreach ($handler in $data.EventHandlers) {
                     if ($null -ne $handler.Score -and $null -ne $handler.Score.Min -and $null -ne $handler.Score.Max) {
-                        $handler.Score.Min = [Math]::Max(0.0, [Math]::Round(([double]$handler.Score.Min) * $harvestYield, 4))
-                        $handler.Score.Max = [Math]::Max(0.0, [Math]::Round(([double]$handler.Score.Max) * $harvestYield, 4))
+                        $handler.Score.Min = [Math]::Max(0.0, [Math]::Round(([double]$handler.Score.Min) * $cfEff, 4))
+                        $handler.Score.Max = [Math]::Max(0.0, [Math]::Round(([double]$handler.Score.Max) * $cfEff, 4))
                         $changed = $true
                     }
                 }
@@ -623,6 +721,15 @@ function Build-MultiplierPak {
                 }
             }
             if ($contextualMod -gt 0) { Write-Host "    Modified $contextualMod contextual destroy score tables" }
+
+            if ($perResourceActive) {
+                $report = ($perFamilyApplied.GetEnumerator() | Sort-Object Name | ForEach-Object { "$($_.Key)=$($_.Value)" }) -join ", "
+                Write-Host "    Per-resource matches: $report"
+                $unmatched = @($perFamilyApplied.GetEnumerator() | Where-Object { $_.Value -eq 0 } | ForEach-Object { $_.Key })
+                if ($unmatched.Count -gt 0) {
+                    Write-Warning "Per-resource keys with zero matches (typo or unsupported family?): $($unmatched -join ', ')"
+                }
+            }
         }
 
         if ($modifiedCount -eq 0) {


### PR DESCRIPTION
Optional new INI lets servers scale wood, stone, ore, sulfur, etc. independently on top of multipliers.harvest_yield. Effective multiplier per loot entry is harvest_yield * <per-resource value>. Default 1.0 for every resource = no per-resource override.

Resource family is detected by matching `Resource_<Name>_T<digit>` in each loot entry's path (Wood, Stone, CopperOre, FiberPlant, Sulfur, Iron, etc.). Unknown families fall through to harvest_yield only.

Targets: ResourcesSpawners JSONs + LootTables/Foliage/*.json LootData entries + the three contextual destroy-score files (SegmentTrees -> Wood, CopperCaves -> CopperOre, IronCaverns -> Iron).

Edits to the new INI trigger a PAK rebuild on the next launch via the existing hash-tracking mechanism in WindrosePlus-BuildPak.ps1. The /api/pak-status endpoint also picks up edits.