### PR TITLE
Increase JSON serialization depth to prevent truncation in PAK builds

### DIFF
--- a/server/windrose_plus_server.ps1
+++ b/server/windrose_plus_server.ps1
@@ -322,7 +322,7 @@ Register-ObjectEvent $tileGenTimer Elapsed -Action {
                     state = "running"
                     ts = $started
                     script = $tileGenScript
-                } | ConvertTo-Json -Compress), [System.Text.UTF8Encoding]::new($false))
+                } | ConvertTo-Json -Depth 100 -Compress), [System.Text.UTF8Encoding]::new($false))
                 $output = (& $tileGenScript -GameDir $gameDir 2>&1 | Out-String).Trim()
                 [System.IO.File]::WriteAllText($tileGenStatus, (@{
                     state = "complete"
@@ -330,7 +330,7 @@ Register-ObjectEvent $tileGenTimer Elapsed -Action {
                     started_ts = $started
                     script = $tileGenScript
                     output = $output
-                } | ConvertTo-Json -Depth 4 -Compress), [System.Text.UTF8Encoding]::new($false))
+                } | ConvertTo-Json -Depth 100 -Compress), [System.Text.UTF8Encoding]::new($false))
                 Write-Host "Map tiles generated."
             } catch {
                 $msg = $_.Exception.Message
@@ -339,7 +339,7 @@ Register-ObjectEvent $tileGenTimer Elapsed -Action {
                     ts = [long][DateTimeOffset]::UtcNow.ToUnixTimeSeconds()
                     script = $tileGenScript
                     error = $msg
-                } | ConvertTo-Json -Compress), [System.Text.UTF8Encoding]::new($false))
+                } | ConvertTo-Json -Depth 100 -Compress), [System.Text.UTF8Encoding]::new($false))
                 Write-Host "Tile generation failed: $msg"
             }
         } else {
@@ -348,14 +348,14 @@ Register-ObjectEvent $tileGenTimer Elapsed -Action {
                 ts = [long][DateTimeOffset]::UtcNow.ToUnixTimeSeconds()
                 script = $tileGenScript
                 error = "generateTiles.ps1 not found"
-            } | ConvertTo-Json -Compress), [System.Text.UTF8Encoding]::new($false))
+            } | ConvertTo-Json -Depth 100 -Compress), [System.Text.UTF8Encoding]::new($false))
         }
     }
 } | Out-Null
 $tileGenTimer.Start()
 
 function Send-Json($context, $data, $statusCode = 200) {
-    $json = if ($null -eq $data) { '{}' } else { $data | ConvertTo-Json -Depth 10 -Compress }
+    $json = if ($null -eq $data) { '{}' } else { $data | ConvertTo-Json -Depth 100 -Compress }
     if ([string]::IsNullOrEmpty($json)) { $json = '{}' }
     $buffer = [System.Text.Encoding]::UTF8.GetBytes($json)
     $context.Response.StatusCode = $statusCode
@@ -368,7 +368,7 @@ function Send-Json($context, $data, $statusCode = 200) {
 
 function Write-AtomicUtf8Json($path, $data) {
     $tmpPath = "$path.tmp"
-    $json = $data | ConvertTo-Json -Depth 10 -Compress
+    $json = $data | ConvertTo-Json -Depth 100 -Compress
     [System.IO.File]::WriteAllText($tmpPath, $json, [System.Text.UTF8Encoding]::new($false))
     if (Test-Path -LiteralPath $path) {
         Remove-Item -LiteralPath $path -Force -ErrorAction SilentlyContinue

--- a/tools/lib/MultiplierPakBuilder.ps1
+++ b/tools/lib/MultiplierPakBuilder.ps1
@@ -385,7 +385,7 @@ function Build-MultiplierPak {
                 if ($changed) {
                     $outPath = Join-Path $tmpDir $lf.Trim()
                     New-Item -ItemType Directory -Force -Path (Split-Path $outPath) | Out-Null
-                    [System.IO.File]::WriteAllText($outPath, ($data | ConvertTo-Json -Depth 10), [System.Text.UTF8Encoding]::new($false))
+                    [System.IO.File]::WriteAllText($outPath, ($data | ConvertTo-Json -Depth 100), [System.Text.UTF8Encoding]::new($false))
                     $modifiedCount++
                 }
             }
@@ -414,7 +414,7 @@ function Build-MultiplierPak {
                 if ($changed) {
                     $outPath = Join-Path $tmpDir $xf
                     New-Item -ItemType Directory -Force -Path (Split-Path $outPath) | Out-Null
-                    [System.IO.File]::WriteAllText($outPath, ($data | ConvertTo-Json -Depth 10), [System.Text.UTF8Encoding]::new($false))
+                    [System.IO.File]::WriteAllText($outPath, ($data | ConvertTo-Json -Depth 100), [System.Text.UTF8Encoding]::new($false))
                     $modifiedCount++
                     Write-Host "    Modified $xf"
                 }
@@ -453,7 +453,7 @@ function Build-MultiplierPak {
                 if ($changed) {
                     $outPath = Join-Path $tmpDir $rf.Trim()
                     New-Item -ItemType Directory -Force -Path (Split-Path $outPath) | Out-Null
-                    [System.IO.File]::WriteAllText($outPath, ($data | ConvertTo-Json -Depth 10), [System.Text.UTF8Encoding]::new($false))
+                    [System.IO.File]::WriteAllText($outPath, ($data | ConvertTo-Json -Depth 100), [System.Text.UTF8Encoding]::new($false))
                     $modifiedCount++
                     $recipeMod++
                 }
@@ -521,7 +521,7 @@ function Build-MultiplierPak {
                     New-Item -ItemType Directory -Force -Path (Split-Path $outPath) | Out-Null
                     $modifiedCount++
                 }
-                [System.IO.File]::WriteAllText($outPath, ($data | ConvertTo-Json -Depth 10), [System.Text.UTF8Encoding]::new($false))
+                [System.IO.File]::WriteAllText($outPath, ($data | ConvertTo-Json -Depth 100), [System.Text.UTF8Encoding]::new($false))
                 $cookMod++
             }
             Write-Host "    Modified $cookMod recipes"
@@ -579,7 +579,7 @@ function Build-MultiplierPak {
                 if ($changed) {
                     $outPath = Join-Path $tmpDir $hf.Trim()
                     New-Item -ItemType Directory -Force -Path (Split-Path $outPath) | Out-Null
-                    [System.IO.File]::WriteAllText($outPath, ($data | ConvertTo-Json -Depth 10), [System.Text.UTF8Encoding]::new($false))
+                    [System.IO.File]::WriteAllText($outPath, ($data | ConvertTo-Json -Depth 100), [System.Text.UTF8Encoding]::new($false))
                     $modifiedCount++
                     $harvMod++
                 }
@@ -625,7 +625,7 @@ function Build-MultiplierPak {
                 }
                 if ($changed) {
                     New-Item -ItemType Directory -Force -Path (Split-Path $outPath) | Out-Null
-                    [System.IO.File]::WriteAllText($outPath, ($data | ConvertTo-Json -Depth 10), [System.Text.UTF8Encoding]::new($false))
+                    [System.IO.File]::WriteAllText($outPath, ($data | ConvertTo-Json -Depth 100), [System.Text.UTF8Encoding]::new($false))
                     if (-not $existedBefore) { $modifiedCount++ }
                     $foliageMod++
                 }
@@ -671,7 +671,7 @@ function Build-MultiplierPak {
                 }
                 if ($changed) {
                     New-Item -ItemType Directory -Force -Path (Split-Path $outPath) | Out-Null
-                    [System.IO.File]::WriteAllText($outPath, ($data | ConvertTo-Json -Depth 10), [System.Text.UTF8Encoding]::new($false))
+                    [System.IO.File]::WriteAllText($outPath, ($data | ConvertTo-Json -Depth 100), [System.Text.UTF8Encoding]::new($false))
                     if (-not $existedBefore) { $modifiedCount++ }
                     $pickupMod++
                 }
@@ -721,7 +721,7 @@ function Build-MultiplierPak {
                 }
                 if ($changed) {
                     New-Item -ItemType Directory -Force -Path (Split-Path $outPath) | Out-Null
-                    [System.IO.File]::WriteAllText($outPath, ($data | ConvertTo-Json -Depth 10), [System.Text.UTF8Encoding]::new($false))
+                    [System.IO.File]::WriteAllText($outPath, ($data | ConvertTo-Json -Depth 100), [System.Text.UTF8Encoding]::new($false))
                     if (-not $existedBefore) { $modifiedCount++ }
                     $contextualMod++
                 }


### PR DESCRIPTION
Fixes #73

Updates build and server-side `ConvertTo-Json` calls to use `-Depth 100`.

Previously, lower depths (or PowerShell’s default depth when unspecified) caused truncation of deeply nested game data structures during PAK generation. This resulted in warnings and could lead to incomplete or malformed JSON output.

This change ensures complete serialization of complex assets such as loot tables, recipes, and contextual spawners, preventing truncation during PAK builds.