### PR TITLE
Fix harvest per-resource matching for spawners and Linux docker

### DIFF
--- a/tools/lib/MultiplierPakBuilder.ps1
+++ b/tools/lib/MultiplierPakBuilder.ps1
@@ -200,13 +200,18 @@ function Read-HarvestIni {
     return $out
 }
 
-# Pull the resource family from a UE LootItem soft-object path.
-# `/R5BusinessRules/.../DA_DID_Resource_Wood_T01.DA_DID_Resource_Wood_T01`
-# -> "Wood". Returns $null when nothing matches.
+# Pull the resource family from a UE asset soft-object path. Matches both
+# loot-table item paths (`.../Resource_Wood_T01...`) and the BP_Mineral_*
+# blueprint paths used in ResourceSpawner Assets[]
+# (`/Game/.../BP_Mineral_Clay_T01_C`). Returns $null when nothing matches.
+#
+# Note: the Linux docker installer's sed pass rewrites `\<alnum>` between
+# alnum chars to `/<alnum>` (path-separator fixup for Windows literals),
+# which would mangle regex shorthand like `\d` to `/d`. Use [0-9] instead.
 function Get-ResourceFamily {
     param([string]$LootItemPath)
     if (-not $LootItemPath) { return $null }
-    if ($LootItemPath -match 'Resource_([A-Za-z][A-Za-z0-9]*)_T\d') {
+    if ($LootItemPath -match '(?:Resource|Mineral)_([A-Za-z][A-Za-z0-9]*)_T[0-9]') {
         return $Matches[1]
     }
     return $null
@@ -563,7 +568,16 @@ function Build-MultiplierPak {
                     foreach ($entry in $variant.Collection) {
                         if ($null -ne $entry.Amount -and $null -ne $entry.Amount.Min -and $null -ne $entry.Amount.Max) {
                             $resMult = 1.0
-                            $family = Get-ResourceFamily -LootItemPath $entry.ResourceParams
+                            # ResourceSpawner entries reference one or more BP
+                            # asset paths via Assets[] (e.g. BP_Mineral_Clay_T01).
+                            # Use the first that yields a family.
+                            $family = $null
+                            if ($entry.Assets) {
+                                foreach ($a in $entry.Assets) {
+                                    $f = Get-ResourceFamily -LootItemPath $a
+                                    if ($f) { $family = $f; break }
+                                }
+                            }
                             if ($family -and $perResource.ContainsKey($family)) {
                                 $resMult = $perResource[$family]
                                 if ($perFamilyApplied.ContainsKey($family)) { $perFamilyApplied[$family]++ }


### PR DESCRIPTION
Two bugs together caused the v1.1.18 per-resource harvest INI to apply zero overrides on Linux dedicated servers, even when base harvest_yield was 1.0 and per-resource keys were correctly set:

1. ResourceSpawners walk read entry.ResourceParams, which does not exist on the schema. Spawner entries reference assets via Assets[] (an array of soft-object paths, e.g. BP_Mineral_Clay_T01_C). With the wrong field, $family was always $null, $resMult stayed 1.0, and with base 1.0 every entry was skipped via the "$eff -eq 1.0" guard. Switch to walking Assets[] and broaden the regex in Get-ResourceFamily to accept the BP_Mineral_<Family>_T<n> pattern alongside the existing Resource_<Family>_T<n>.

2. The regex used `\d` shorthand. The windrose-server-docker installer runs a sed pass over every shipped .ps1 to rewrite Windows-style path separators, which also rewrites `\<alnum>` between alnum chars to `/<alnum>`. That turned `_T\d` into `_T/d`, breaking the regex on Linux containers (Foliage and PickupResource walks reported zero matches; only the hardcoded-family contextual files still worked). Use `[0-9]` instead — survives the sed pass and matches identically.

Verified against pakchunk0-WindowsServer.pak with the user's harvest INI: ResourceSpawners 0->1, Foliage 0->128, PickupResource 0->3, Contextual 3->3 modifications. Per-family applied counts now reflect the actual loot-table coverage (Wood=143, Stone=19, FiberPlant=44, Iron=16, Clay=5, etc.) instead of the previous all-zero.