### PR TITLE
Fix public Sea Chart rendering missing tiles as red squares

### DIFF
--- a/server/web/livemap/index.html
+++ b/server/web/livemap/index.html
@@ -121,7 +121,12 @@
                 tileSize: 256,
                 noWrap: true,
                 bounds: L.latLngBounds([W.minY, W.minX], [W.maxY, W.maxX]),
-                errorTileUrl: 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwADhQGAWjR9awAAAABJRU5ErkJggg=='
+                // Truly transparent 1×1 RGBA PNG. The previous literal here decoded to
+                // rgba(255,0,0,127), which Leaflet stretched into every missing tile slot
+                // — three big red squares appeared at the southern edge of the public
+                // Sea Chart whenever those tiles were not generated. Auth dashboard
+                // already fixed this in server/web/index.html; mirror the same PNG here.
+                errorTileUrl: 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNgYGBgAAAABQABeqhXUAAAAABJRU5ErkJggg=='
             }).addTo(map);
 
             map.fitBounds(IB);


### PR DESCRIPTION
The standalone /public-map livemap viewer's errorTileUrl was a 1x1 RGBA PNG that decoded to rgba(255,0,0,127). Leaflet stretches the error tile to fill every missing tile slot, so any zoom level with ungenerated tiles rendered the affected area as half-opaque red — typically three big red squares along the southern edge where the world bounds extend past the generated tile pyramid.

The same bug existed in the authenticated dashboard's livemap and was fixed there earlier with a comment explaining the cause; this commit copies the truly-transparent PNG into the public map and mirrors the warning comment so the trap can't be reintroduced.

Single-character (literally one byte in the IDAT zlib stream) change to the base64; pixel goes from rgba(255,0,0,127) to rgba(0,0,0,0).