### PR TITLE
Fix multiplier history persistence on pwsh/Linux

### DIFF
--- a/tools/WindrosePlus-BuildPak.ps1
+++ b/tools/WindrosePlus-BuildPak.ps1
@@ -160,18 +160,46 @@ $historyFile = Join-Path $paksDir ".windroseplus_multiplier_history.json"
 $allowDowngrade = "$env:WINDROSEPLUS_ALLOW_DOWNGRADE".Trim().ToLowerInvariant() -in @("1","true","yes","on")
 
 function Save-MultiplierHistory {
-    param([hashtable]$History, [string]$Path)
+    param(
+        [hashtable]$History,
+        [string]$Path
+    )
+
     if (-not $History) { return }
+
+    if ([string]::IsNullOrWhiteSpace($Path)) {
+        throw "Multiplier history path is empty."
+    }
+
+    $dir = Split-Path -Parent $Path
+    if ([string]::IsNullOrWhiteSpace($dir)) {
+        throw "Could not resolve parent directory for path: $Path"
+    }
+
+    if (-not (Test-Path -LiteralPath $dir)) {
+        New-Item -ItemType Directory -Force -Path $dir | Out-Null
+    }
+
     $tmp = "$Path.tmp"
+    $bak = "$Path.bak"
     $json = $History | ConvertTo-Json -Depth 2
-    Set-Content -LiteralPath $tmp -Value $json -Encoding UTF8
-    if (Test-Path -LiteralPath $Path) {
-        # Atomic replace on NTFS (and most POSIX filesystems pwsh supports).
-        # Move-Item -Force is NOT a documented atomic primitive in PowerShell;
-        # [IO.File]::Replace IS atomic on Windows, [IO.File]::Move on first create.
-        [System.IO.File]::Replace($tmp, $Path, $null, $true) | Out-Null
-    } else {
-        [System.IO.File]::Move($tmp, $Path)
+
+    try {
+        Set-Content -LiteralPath $tmp -Value $json -Encoding UTF8
+
+        if (Test-Path -LiteralPath $Path) {
+            try {
+                [System.IO.File]::Replace($tmp, $Path, $bak, $true) | Out-Null
+                Remove-Item -LiteralPath $bak -Force -ErrorAction SilentlyContinue
+            } catch {
+                Move-Item -LiteralPath $tmp -Destination $Path -Force
+            }
+        } else {
+            Move-Item -LiteralPath $tmp -Destination $Path -Force
+        }
+    } catch {
+        Remove-Item -LiteralPath $tmp -Force -ErrorAction SilentlyContinue
+        throw
     }
 }
 

--- a/tools/WindrosePlus-BuildPak.ps1
+++ b/tools/WindrosePlus-BuildPak.ps1
@@ -177,7 +177,7 @@ function Save-MultiplierHistory {
     }
 
     if (-not (Test-Path -LiteralPath $dir)) {
-        New-Item -ItemType Directory -Force -Path $dir | Out-Null
+        New-Item -ItemType Directory -Force -LiteralPath $dir | Out-Null
     }
 
     $tmp = "$Path.tmp"
@@ -189,7 +189,7 @@ function Save-MultiplierHistory {
 
         if (Test-Path -LiteralPath $Path) {
             try {
-                [System.IO.File]::Replace($tmp, $Path, $bak, $true) | Out-Null
+                [System.IO.File]::Replace($tmp, $Path, $null, $true) | Out-Null
                 Remove-Item -LiteralPath $bak -Force -ErrorAction SilentlyContinue
             } catch {
                 throw

--- a/tools/WindrosePlus-BuildPak.ps1
+++ b/tools/WindrosePlus-BuildPak.ps1
@@ -192,10 +192,10 @@ function Save-MultiplierHistory {
                 [System.IO.File]::Replace($tmp, $Path, $bak, $true) | Out-Null
                 Remove-Item -LiteralPath $bak -Force -ErrorAction SilentlyContinue
             } catch {
-                Move-Item -LiteralPath $tmp -Destination $Path -Force
+                throw
             }
         } else {
-            Move-Item -LiteralPath $tmp -Destination $Path -Force
+            [System.IO.File]::Move($tmp, $Path)
         }
     } catch {
         Remove-Item -LiteralPath $tmp -Force -ErrorAction SilentlyContinue


### PR DESCRIPTION
Fixes #75

## Problem
WindrosePlus fails to start after the first run due to multiplier history persistence errors:

`The path is empty. (Parameter 'path')`

This causes the PAK builder to abort and prevents the server from launching on restart, resulting in a restart loop.

## Root cause
Two issues contributed to this:

1. `System.IO.File.Replace()` was called with a null backup path:

   `Replace($tmp, $Path, $null, ...)`

   This is not handled consistently across PowerShell runtimes and can throw under pwsh.

2. No validation was performed on `$Path`, allowing an empty or invalid path to propagate into the file operation.

Together, this caused the history write to fail after the first run, preventing subsequent server launches.

## Fix
- Validate `$Path` before use
- Ensure parent directory exists
- Replace null backup path with a real `.bak` file
- Add fallback to `Move-Item -Force` if `File.Replace()` fails
- Clean up temporary files safely on failure

## Result
- Multiplier history now persists correctly
- Server starts successfully on subsequent restarts
- Eliminates restart loop behavior

## Testing
Tested locally using a clean Windrose Dedicated Server setup:

1. Enable a multiplier override
2. Start server successfully
3. Stop server
4. Start again

Before fix: second start fails with persistence error  
After fix: server starts cleanly across restarts