### PR TITLE
Add multiplier PAK disable fallback and improve stale warning messaging

### DIFF
--- a/server/windrose_plus_server.ps1
+++ b/server/windrose_plus_server.ps1
@@ -945,7 +945,7 @@ try {
                                     $t = (Get-Item $multPak).LastWriteTimeUtc.Ticks
                                     if ($t -lt $pakMtime) { $pakMtime = $t }
                                 } else {
-                                    $stale = $true; $reason = "Multipliers PAK missing but config requires one"
+                                    $stale = $true; $reason = "Multiplier PAK generation disabled or missing while multiplier config is non-default"
                                 }
                             }
                             if ($expectCtPak -and -not $stale) {

--- a/tools/WindrosePlus-BuildPak.ps1
+++ b/tools/WindrosePlus-BuildPak.ps1
@@ -157,6 +157,8 @@ if ($multipliers.ContainsKey("craft_cost")) {
 # succeeds — never on dry runs, never on failed builds.
 $ratchetKeys = @("xp")
 $historyFile = Join-Path $paksDir ".windroseplus_multiplier_history.json"
+$multiplierPakFile = Join-Path $paksDir "WindrosePlus_Multipliers_P.pak"
+$disableMultiplierPak = "$env:WINDROSEPLUS_DISABLE_MULTIPLIER_PAK".Trim().ToLowerInvariant() -in @("1","true","yes","on")
 $allowDowngrade = "$env:WINDROSEPLUS_ALLOW_DOWNGRADE".Trim().ToLowerInvariant() -in @("1","true","yes","on")
 
 function Save-MultiplierHistory {
@@ -189,8 +191,10 @@ function Save-MultiplierHistory {
 
         if (Test-Path -LiteralPath $Path) {
             try {
-                [System.IO.File]::Replace($tmp, $Path, $null, $true) | Out-Null
-                Remove-Item -LiteralPath $bak -Force -ErrorAction SilentlyContinue
+                [System.IO.File]::Replace($tmp, $Path, $bak, $true) | Out-Null
+                if (Test-Path -LiteralPath $bak) {
+                    Remove-Item -LiteralPath $bak -Force -ErrorAction SilentlyContinue
+                }
             } catch {
                 throw
             }
@@ -351,6 +355,16 @@ if (-not $hasMultipliers) {
         if ($v -ne 1.0) { $hasMultipliers = $true; break }
     }
 }
+
+if ($disableMultiplierPak -and $hasMultipliers) {
+    Write-Warning "WINDROSEPLUS_DISABLE_MULTIPLIER_PAK enabled. Removing/skipping multiplier PAK generation."
+
+    Remove-Item -LiteralPath $multiplierPakFile -Force -ErrorAction SilentlyContinue
+    Remove-Item -LiteralPath $historyFile -Force -ErrorAction SilentlyContinue
+
+    $hasMultipliers = $false
+}
+
 $hasCT = ($ctConfig.Count -gt 0)
 
 # --- No-op path ---
@@ -715,7 +729,7 @@ if ($hasCT) {
 # history. Hard fail if we cannot persist — without this file the next
 # downgrade is unprotected, which is exactly the failure mode the ratchet
 # exists to prevent (issue #69).
-if (-not $DryRun) {
+if ($hasMultipliers -and -not $DryRun) {
     try {
         Save-MultiplierHistory -History $plannedHistory -Path $historyFile
     } catch {


### PR DESCRIPTION
## Summary

Adds an emergency fallback path to disable generated multiplier PAKs via environment variable while preserving normal WindrosePlus runtime/server functionality.

Also fixes multiplier history persistence on pwsh/.NET and improves dashboard stale-state messaging.

---

## Changes

### BuildPak

* Added `WINDROSEPLUS_DISABLE_MULTIPLIER_PAK`
* Removes/skips generated multiplier PAK creation when enabled
* Removes stale multiplier PAK/history files when disabled
* Prevents multiplier history persistence when multiplier PAK generation is skipped

### History persistence

Fixes:

```powershell
[System.IO.File]::Replace($tmp, $Path, $null, $true)
```

which throws on pwsh/.NET because `destinationBackupFileName` cannot be null.

Now uses:

```powershell
[System.IO.File]::Replace($tmp, $Path, $bak, $true)
```

with cleanup handling afterward.

### Dashboard messaging

Updated stale warning wording from:

> Multipliers PAK missing but config requires one

to:

> Multiplier PAK generation disabled or missing while multiplier config is non-default

to better reflect intentional disable scenarios.

---

## Testing

Environment:

* Windrose `0.10.0.5.120`
* WindrosePlus `v1.1.22`

Observed issue:

* Generated `WindrosePlus_Multipliers_P.pak` caused backpack inventory slot collapse/desync behavior
* Reproduced with multiplier overrides enabled
* Same character/save functioned correctly when multiplier PAK generation was disabled

Validation:

* Server starts normally with fallback enabled
* Dashboard reflects disable state correctly
* No multiplier PAK generated
* Existing character loads correctly
* Backpack slots behave normally after equip/unequip testing
* Inventory state remains stable after item movement/relog testing

---

## Notes

This acts as a compatibility/safety fallback while the underlying multiplier PAK incompatibility with current Windrose builds is investigated further.
