### PR TITLE
fix: use Move-Item on Linux/macOS instead of Windows-only File.Replace

### DIFF
--- a/tools/WindrosePlus-BuildPak.ps1
+++ b/tools/WindrosePlus-BuildPak.ps1
@@ -221,8 +221,12 @@ function Save-MultiplierHistory {
 
         if (Test-Path -LiteralPath $Path) {
             try {
-                [System.IO.File]::Replace($tmp, $Path, $null, $true) | Out-Null
-                Remove-Item -LiteralPath $bak -Force -ErrorAction SilentlyContinue
+                if ($IsLinux -or $IsMacOS) {
+                    Move-Item -LiteralPath $tmp -Destination $Path -Force
+                } else {
+                    [System.IO.File]::Replace($tmp, $Path, $null, $true) | Out-Null
+                    Remove-Item -LiteralPath $bak -Force -ErrorAction SilentlyContinue
+                }
             } catch {
                 throw
             }


### PR DESCRIPTION
## Summary

- `[System.IO.File]::Replace()` is a Windows-only .NET API that throws on Linux/macOS
- This causes `WindrosePlus-BuildPak.ps1` to fail with exit code 4, aborting server startup
- On Linux Docker containers with `restart: unless-stopped`, this creates an infinite boot loop

## Fix

On Linux and macOS, use `Move-Item -Force` as a cross-platform alternative for atomic file replacement. Windows continues to use `File.Replace()` for its atomic replace-with-backup semantics.

## Reproduction

Run a Windrose+ server on Linux (e.g. Docker container). The PAK builder fails at the `Save-MultiplierHistory` step with:

```
FAILED to persist multiplier history at .../.windroseplus_multiplier_history.json:
Exception calling "Replace" with "4" argument(s): "The value cannot be an empty string. (Parameter 'path')"
```

The server then exits and restarts in a loop.

## Testing

Verified on a Linux Docker host — server starts successfully and remains healthy after the fix.