### PR TITLE
Removed authentication for static vendor files

### DIFF
--- a/server/windrose_plus_server.ps1
+++ b/server/windrose_plus_server.ps1
@@ -1090,6 +1090,21 @@ try {
                 continue
             }
 
+            # Static self-hosted vendor files - no auth.
+            # Those are libraries used in any pages, private or public
+            if ($path.StartsWith("/vendor/")) {
+                $vendorRoot = [System.IO.Path]::GetFullPath((Join-Path $webDir "vendor"))
+                $candidate   = [System.IO.Path]::GetFullPath((Join-Path $webDir ($path.TrimStart("/").Replace("/", "\"))))
+
+                if (-not $candidate.StartsWith($vendorRoot + $sep, [System.StringComparison]::OrdinalIgnoreCase)) {
+                    $context.Response.StatusCode = 403
+                    $context.Response.Close()
+                    continue
+                }
+                Send-File $context $candidate
+                continue
+            }
+
             # Static game-catalog assets (item metadata + icons) — no auth.
             # This is generic Windrose game data, identical on every server,
             # no player or server identifying information. Letting public


### PR DESCRIPTION
## Context

Since 1.3.3, the vendor files are now self-hosted, instead of using unpkg.
This change broke some public pages, including the Public Map, which depends on /vendor/* pages to correctly render the map.

## Changes

I added `/vendor/` route as public, based on how it is done for the `/catalog/` route. 
This exposes fonts, and leaflet dependencies as public resources.

## Linked issues
- #117 